### PR TITLE
Add MomentumVersion build property to deploy template

### DIFF
--- a/deploy-template-updated.yml
+++ b/deploy-template-updated.yml
@@ -1,0 +1,264 @@
+name: Deploy Momentum Template
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.template.config/**'
+      - 'src/**'
+      - 'docs/**'
+      - 'compose.yml'
+      - 'README.md'
+      - 'ProjectREADME.md'
+      - 'Directory.Build.props'
+      - 'Directory.Packages.props'
+      - 'AppDomain.slnx'
+      - 'AppDomain.ruleset'
+      - 'libs/src/**'
+    tags:
+      - 'template'
+      - 't*.*.*'
+  workflow_dispatch:
+    inputs:
+      deploy-type:
+        description: 'Type of deployment'
+        required: true
+        default: 'prerelease'
+        type: choice
+        options:
+          - prerelease
+          - release
+          - test-prerelease
+          - test-release
+      nuget-source:
+        description: 'NuGet source (for testing)'
+        required: false
+        default: 'https://api.nuget.org/v3/index.json'
+      momentum-version:
+        description: 'Momentum library version (leave empty for latest stable)'
+        required: false
+        default: ''
+
+env:
+  DOTNET_VERSION: '9.0.x'
+
+concurrency:
+  group: deploy-template-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+jobs:
+  deploy-template:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get Momentum Version
+        id: momentum-version
+        shell: bash
+        run: |
+          if [ -n "${{ github.event.inputs.momentum-version }}" ]; then
+            MOMENTUM_VERSION="${{ github.event.inputs.momentum-version }}"
+            echo "Using manual override: $MOMENTUM_VERSION"
+          else
+            # Fetch latest stable version from NuGet
+            # Using Momentum.Extensions.Abstractions as the reference package
+            MOMENTUM_VERSION=$(curl -s "https://api.nuget.org/v3-flatcontainer/momentum.extensions.abstractions/index.json" | jq -r '.versions | map(select(test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))) | last')
+            if [ -z "$MOMENTUM_VERSION" ] || [ "$MOMENTUM_VERSION" = "null" ]; then
+              # Fallback to any latest version if no stable found
+              MOMENTUM_VERSION=$(curl -s "https://api.nuget.org/v3-flatcontainer/momentum.extensions.abstractions/index.json" | jq -r '.versions[-1]')
+            fi
+            echo "Using latest stable version: $MOMENTUM_VERSION"
+          fi
+          echo "version=$MOMENTUM_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Set deployment options
+        id: options
+        shell: bash
+        run: |
+          DEPLOY_PRERELEASE=false
+          DEPLOY_RELEASE=false
+          IS_TEST=false
+          NUGET_SOURCE="https://api.nuget.org/v3/index.json"
+
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && ("${{ github.event.inputs.deploy-type }}" == "test-prerelease" || "${{ github.event.inputs.deploy-type }}" == "test-release") ]]; then
+            IS_TEST=true
+            NUGET_SOURCE="https://int.nugettest.org/v3/index.json"
+            if [ -n "${{ github.event.inputs.nuget-source }}" ]; then
+              NUGET_SOURCE="${{ github.event.inputs.nuget-source }}"
+            fi
+          fi
+
+          if [[ ("${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main") || ("${{ github.event_name }}" == "workflow_dispatch" && ("${{ github.event.inputs.deploy-type }}" == "prerelease" || "${{ github.event.inputs.deploy-type }}" == "test-prerelease")) ]]; then
+            DEPLOY_PRERELEASE=true
+          fi
+
+          if [[ "${{ github.ref_name }}" == "template" || ("${{ github.event_name }}" == "workflow_dispatch" && ("${{ github.event.inputs.deploy-type }}" == "release" || "${{ github.event.inputs.deploy-type }}" == "test-release")) ]]; then
+            DEPLOY_RELEASE=true
+          fi
+
+          echo "prerelease=$DEPLOY_PRERELEASE" >> $GITHUB_OUTPUT
+          echo "release=$DEPLOY_RELEASE" >> $GITHUB_OUTPUT
+          echo "test=$IS_TEST" >> $GITHUB_OUTPUT
+          echo "nuget_source=$NUGET_SOURCE" >> $GITHUB_OUTPUT
+
+      - name: Calculate pre-release version
+        if: steps.options.outputs.prerelease == 'true'
+        id: prerelease-version
+        uses: ./.github/actions/version-calculate
+        with:
+          version-file: .template.config/version.txt
+          release-type: prerelease
+          check-changes: false
+
+      - name: Generate pre-release notes (Template)
+        if: steps.options.outputs.prerelease == 'true' && steps.prerelease-version.outputs.skip != 'true'
+        uses: ./.github/actions/generate-template-release-notes
+        with:
+          version: ${{ steps.prerelease-version.outputs.version }}
+          tag: ${{ steps.prerelease-version.outputs.tag }}
+          release-type: prerelease
+          output-file: prerelease_notes.md
+
+      - name: Create GitHub pre-release (Template)
+        if: steps.options.outputs.prerelease == 'true' && steps.prerelease-version.outputs.skip != 'true' && steps.options.outputs.test != 'true'
+        run: |
+          gh release create ${{ steps.prerelease-version.outputs.tag }} \
+            --title "Momentum Template ${{ steps.prerelease-version.outputs.tag }} (Pre-release)" \
+            --notes-file prerelease_notes.md \
+            --prerelease \
+            --target main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pack Template (Pre-release)
+        if: steps.options.outputs.prerelease == 'true' && steps.prerelease-version.outputs.skip != 'true'
+        uses: ./.github/actions/template-pack
+        with:
+          package-id: Momentum.Templates
+          package-version: ${{ steps.prerelease-version.outputs.version }}
+          momentum-version: ${{ steps.momentum-version.outputs.version }}
+
+      - name: Publish Template (Pre-release)
+        if: steps.options.outputs.prerelease == 'true' && steps.prerelease-version.outputs.skip != 'true'
+        shell: bash
+        run: |
+          dotnet nuget push ./artifacts/template/*.nupkg \
+            --api-key ${{ steps.options.outputs.test == 'true' && secrets.NUGET_TEST_API_KEY || secrets.NUGET_API_KEY }} \
+            --source ${{ steps.options.outputs.nuget_source }} \
+            --skip-duplicate
+
+      - name: Verify main branch for release
+        if: steps.options.outputs.release == 'true'
+        shell: bash
+        run: |
+          CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+          if [ "$CURRENT_BRANCH" != "main" ]; then
+            echo "❌ Release must be created from main branch. Current: $CURRENT_BRANCH"
+            exit 1
+          fi
+          echo "✅ Confirmed on main branch"
+
+      - name: Calculate release version
+        if: steps.options.outputs.release == 'true'
+        id: release-version
+        uses: ./.github/actions/version-calculate
+        with:
+          version-file: .template.config/version.txt
+          release-type: stable
+          check-changes: false
+
+      - name: Generate release notes (Template)
+        if: steps.options.outputs.release == 'true'
+        uses: ./.github/actions/generate-template-release-notes
+        with:
+          version: ${{ steps.release-version.outputs.version }}
+          tag: ${{ steps.release-version.outputs.tag }}
+          release-type: stable
+          output-file: release_notes.md
+
+      - name: Create GitHub release (Template)
+        if: steps.options.outputs.release == 'true' && steps.options.outputs.test != 'true'
+        run: |
+          gh release create ${{ steps.release-version.outputs.tag }} \
+            --title "Momentum Template ${{ steps.release-version.outputs.tag }}" \
+            --notes-file release_notes.md \
+            --target main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pack Template (Release)
+        if: steps.options.outputs.release == 'true'
+        uses: ./.github/actions/template-pack
+        with:
+          package-id: Momentum.Templates
+          package-version: ${{ steps.release-version.outputs.version }}
+          momentum-version: ${{ steps.momentum-version.outputs.version }}
+
+      - name: Publish Template (Release)
+        if: steps.options.outputs.release == 'true'
+        shell: bash
+        run: |
+          dotnet nuget push ./artifacts/template/*.nupkg \
+            --api-key ${{ steps.options.outputs.test == 'true' && secrets.NUGET_TEST_API_KEY || secrets.NUGET_API_KEY }} \
+            --source ${{ steps.options.outputs.nuget_source }} \
+            --skip-duplicate
+
+      - name: Deployment Summary
+        shell: bash
+        run: |
+          echo "# 📊 Template Deployment Summary"
+          echo ""
+          
+          echo "## 📦 Momentum Version"
+          echo "   - Version: ${{ steps.momentum-version.outputs.version }}"
+          if [ -n "${{ github.event.inputs.momentum-version }}" ]; then
+            echo "   - Source: Manual override"
+          else
+            echo "   - Source: Latest stable from NuGet"
+          fi
+          echo ""
+
+          if [ "${{ steps.options.outputs.test }}" == "true" ]; then
+            echo "🧪 **Test Deployment Mode**"
+            echo "   - NuGet Source: ${{ steps.options.outputs.nuget_source }}"
+            echo ""
+          fi
+
+          if [ "${{ steps.options.outputs.prerelease }}" == "true" ]; then
+            if [ "${{ steps.prerelease-version.outputs.skip }}" == "true" ]; then
+              echo "⏭️ Pre-release skipped"
+            elif [ -n "${{ steps.prerelease-version.outputs.version }}" ]; then
+              echo "✅ **Pre-release deployed**"
+              echo "   - Version: ${{ steps.prerelease-version.outputs.version }}"
+              echo "   - Tag: ${{ steps.prerelease-version.outputs.tag }}"
+              echo "   - NuGet: ${{ steps.options.outputs.nuget_source }}"
+              if [ "${{ steps.options.outputs.test }}" != "true" ]; then
+                echo "   - GitHub Release: Created"
+              fi
+            else
+              echo "❌ **Pre-release failed**"
+            fi
+          fi
+
+          if [ "${{ steps.options.outputs.release }}" == "true" ]; then
+            if [ -n "${{ steps.release-version.outputs.version }}" ]; then
+              echo "✅ **Release deployed**"
+              echo "   - Version: ${{ steps.release-version.outputs.version }}"
+              echo "   - Tag: ${{ steps.release-version.outputs.tag }}"
+              echo "   - NuGet: ${{ steps.options.outputs.nuget_source }}"
+              if [ "${{ steps.options.outputs.test }}" != "true" ]; then
+                echo "   - GitHub Release: Created"
+              fi
+            else
+              echo "❌ **Release failed**"
+            fi
+          fi

--- a/template-pack-updated.yml
+++ b/template-pack-updated.yml
@@ -1,0 +1,127 @@
+name: 'Pack Template as NuGet'
+description: 'Packs the repository template (.template.config) into a NuGet template package'
+
+inputs:
+  package-id:
+    description: 'NuGet package ID (e.g., Momentum.Templates)'
+    required: true
+  package-version:
+    description: 'Package version'
+    required: true
+  momentum-version:
+    description: 'Momentum library version to use in the template'
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '9.0.x'
+
+    - name: Prepare artifacts dir
+      shell: bash
+      run: |
+        mkdir -p ./artifacts/template
+
+    - name: Set MomentumVersion in Directory.Build.props
+      if: inputs.momentum-version != ''
+      shell: bash
+      run: |
+        echo "Setting MomentumVersion to ${{ inputs.momentum-version }}"
+        
+        # Update Directory.Build.props with MomentumVersion
+        if [ -f "Directory.Build.props" ]; then
+          # Check if MomentumVersion already exists
+          if grep -q "<MomentumVersion>" Directory.Build.props; then
+            # Update existing version
+            sed -i "s|<MomentumVersion>.*</MomentumVersion>|<MomentumVersion>${{ inputs.momentum-version }}</MomentumVersion>|" Directory.Build.props
+          else
+            # Add MomentumVersion property if it doesn't exist
+            sed -i '/<PropertyGroup>/a\    <MomentumVersion>${{ inputs.momentum-version }}</MomentumVersion>' Directory.Build.props
+          fi
+          echo "Updated Directory.Build.props with MomentumVersion=${{ inputs.momentum-version }}"
+        fi
+        
+        # Also update Directory.Packages.props if it exists
+        if [ -f "Directory.Packages.props" ]; then
+          # Update all Momentum.* package references to use the specified version
+          sed -i "s|<PackageVersion Include=\"Momentum\.\([^\"]*\)\" Version=\"[^\"]*\"|<PackageVersion Include=\"Momentum.\1\" Version=\"${{ inputs.momentum-version }}\"|g" Directory.Packages.props
+          echo "Updated Directory.Packages.props with Momentum package versions=${{ inputs.momentum-version }}"
+        fi
+
+    - name: Create nuspec
+      id: nuspec
+      shell: bash
+      run: |
+        PKG_ID='${{ inputs.package-id }}'
+        PKG_VERSION='${{ inputs.package-version }}'
+        MOMENTUM_VERSION='${{ inputs.momentum-version }}'
+        NUSPEC_PATH='./artifacts/template/template.nuspec'
+
+        # Create metadata section with Momentum version info
+        METADATA_DESC="Momentum .NET project template."
+        if [ -n "$MOMENTUM_VERSION" ]; then
+          METADATA_DESC="Momentum .NET project template. (Using Momentum libraries v$MOMENTUM_VERSION)"
+        fi
+
+        cat > "$NUSPEC_PATH" << EOF
+        <?xml version="1.0"?>
+        <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+          <metadata>
+            <id>$PKG_ID</id>
+            <version>$PKG_VERSION</version>
+            <authors>Momentum .NET</authors>
+            <owners>Momentum .NET</owners>
+            <requireLicenseAcceptance>false</requireLicenseAcceptance>
+            <license type="expression">MIT</license>
+            <projectUrl>https://github.com/vgmello/momentum</projectUrl>
+            <description>$METADATA_DESC</description>
+            <packageTypes>
+              <packageType name="Template" />
+            </packageTypes>
+            <tags>dotnet-new;template;momentum</tags>
+          </metadata>
+          <files>
+            <!-- Include template configuration -->
+            <file src=".template.config/**" target="content/" />
+
+            <!-- Include your solution skeleton files/directories -->
+            <file src="src/**" target="content/" />
+            <file src="docs/**" target="content/" />
+            <file src="compose.yml" target="content/" />
+            <file src="README.md" target="content/" />
+            <file src="ProjectREADME.md" target="content/" />
+            <file src="Directory.Build.props" target="content/" />
+            <file src="Directory.Packages.props" target="content/" />
+            <file src="AppDomain.slnx" target="content/" />
+            <file src="AppDomain.ruleset" target="content/" />
+
+            <!-- Include libs sources in template content -->
+            <file src="libs/src/**" target="content/libs/src/" />
+
+            <!-- General include with excludes to avoid CI/dev artifacts -->
+            <file src="**/*" target="content/" exclude=".git/**;**/bin/**;**/obj/**;.github/**;.idea/**;.vscode/**;tests/**;.local/**" />
+          </files>
+        </package>
+        EOF
+
+        echo "nuspec=$NUSPEC_PATH" >> $GITHUB_OUTPUT
+
+    - name: Pack
+      shell: bash
+      run: |
+        dotnet tool install --global nuget-command-line && export PATH="$PATH:$HOME/.dotnet/tools"
+        nuget pack "${{ steps.nuspec.outputs.nuspec }}" -OutputDirectory ./artifacts/template -NoPackageAnalysis
+        echo "📦 Packed template:"
+        ls -la ./artifacts/template
+
+    - name: Restore original files
+      if: inputs.momentum-version != ''
+      shell: bash
+      run: |
+        # Restore the original files after packing
+        git checkout -- Directory.Build.props Directory.Packages.props 2>/dev/null || true
+        echo "Restored original Directory.Build.props and Directory.Packages.props"


### PR DESCRIPTION
This PR implements the requested changes to set the MomentumVersion build property during deployment.

## Changes:
- Add momentum-version input parameter to deploy-template workflow
- Implement automatic fetching of latest stable Momentum version from NuGet
- Update template-pack action to set MomentumVersion in Directory.Build.props
- Add version info to NuGet package description

## Note:
These files need to be manually moved to .github/ directories due to GitHub App permission restrictions.

Closes #10