### PR TITLE
Fix nuget-publish action deployment issue

### DIFF
--- a/.github/actions/deployment-config/action.yml
+++ b/.github/actions/deployment-config/action.yml
@@ -50,7 +50,7 @@ runs:
         # Test deployments
         if [[ "${{ inputs.deploy-type }}" == "test-"* ]]; then
           IS_TEST=true
-          NUGET_SOURCE="https://int.nugettest.org/v3/index.json"
+          NUGET_SOURCE="https://apiint.nugettest.org/v3/index.json"
           if [ -n "${{ inputs.nuget-source-override }}" ]; then
             NUGET_SOURCE="${{ inputs.nuget-source-override }}"
           fi

--- a/.github/actions/nuget-publish/action.yml
+++ b/.github/actions/nuget-publish/action.yml
@@ -49,6 +49,20 @@ runs:
       run: |
         NUGET_OUTPUT_DIR="./_tmp_nuget_output"
 
+        echo "🔍 Debug information:"
+        echo "   Current directory: $(pwd)"
+        echo "   Target path: ${{ inputs.path }}"
+        echo "   Package version: ${{ inputs.package-version }}"
+        echo "   Configuration: ${{ inputs.config }}"
+        
+        # Validate path exists
+        if [ ! -f "${{ inputs.path }}" ] && [ ! -d "${{ inputs.path }}" ]; then
+          echo "❌ Target path '${{ inputs.path }}' does not exist"
+          echo "   Working directory contents:"
+          ls -la
+          exit 1
+        fi
+
         echo "🧹 Cleaning output directory: $NUGET_OUTPUT_DIR"
         rm -rf "$NUGET_OUTPUT_DIR"
         mkdir -p "$NUGET_OUTPUT_DIR"


### PR DESCRIPTION
## Summary
- Fix path validation in nuget-publish GitHub Action
- Add debugging output to help diagnose deployment failures  
- Validate target path exists before attempting dotnet pack
- Fix NuGet test server URL (int.nugettest.org → apiint.nugettest.org)

## Issues Fixed
- Fixed the original deployment failure from https://github.com/vgmello/momentum/actions/runs/17117032750/job/48550060454
- Added path validation and debug information to nuget-publish action
- Corrected the NuGet test server URL to use the proper API endpoint

## Test plan
- [x] Test pack command locally (works)
- [x] Add path validation and debug output
- [x] Fix NuGet test server URL
- [x] Verify GitHub Actions deployment works (successfully published 8/8 packages)

## Verification
The fix has been tested and verified to work in workflow run: https://github.com/vgmello/momentum/actions/runs/17121321437

🤖 Generated with [Claude Code](https://claude.ai/code)