### PR TITLE
Fix GitHub Action to create non-draft releases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,6 +102,7 @@ jobs:
             --title "Momentum Libraries ${{ steps.prerelease-version.outputs.tag }} (Pre-release)" \
             --notes-file prerelease_notes.md \
             --prerelease \
+            --draft=false \
             --target main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -147,6 +148,7 @@ jobs:
           gh release create ${{ steps.release-version.outputs.tag }} \
             --title "Momentum Libraries ${{ steps.release-version.outputs.tag }}" \
             --notes-file release_notes.md \
+            --draft=false \
             --target main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
• Fixed GitHub release creation to publish releases immediately instead of creating drafts
• Added --draft=false flag to both regular and pre-release creation steps in deploy.yml

## Problem
The deploy.yml workflow was creating draft releases when publishing to main, requiring manual intervention to publish them.

## Solution
Added explicit --draft=false flag to the gh release create commands for both:
- Regular releases (line 151)
- Pre-releases (line 105)

## Test plan
- [ ] Verify workflow runs successfully
- [ ] Confirm releases are created as published (non-draft) when triggered

🤖 Generated with [Claude Code](https://claude.ai/code)