### PR TITLE
Move [ExcludeFromCodeCoverage] from assembly-level to individual clas…

### DIFF
--- a/src/AppDomain.AppHost/Extensions/GrpcExtensions.cs
+++ b/src/AppDomain.AppHost/Extensions/GrpcExtensions.cs
@@ -5,6 +5,7 @@ namespace AppDomain.AppHost.Extensions;
 /// <summary>
 ///     Provides extension methods for gRPC endpoint configuration in .NET Aspire orchestration.
 /// </summary>
+[ExcludeFromCodeCoverage]
 public static class GrpcExtensions
 {
     /// <summary>

--- a/src/AppDomain.AppHost/Extensions/LaunchProfileExtensions.cs
+++ b/src/AppDomain.AppHost/Extensions/LaunchProfileExtensions.cs
@@ -8,6 +8,7 @@ namespace AppDomain.AppHost.Extensions;
 /// <summary>
 ///     Provides extension methods for integrating launch profile endpoint configurations with .NET Aspire orchestration.
 /// </summary>
+[ExcludeFromCodeCoverage]
 public static class LaunchProfileExtensions
 {
     private const string KestrelEndpointsPrefix = "KESTREL__ENDPOINTS__";

--- a/src/AppDomain.AppHost/Extensions/LiquibaseExtensions.cs
+++ b/src/AppDomain.AppHost/Extensions/LiquibaseExtensions.cs
@@ -5,6 +5,7 @@ namespace AppDomain.AppHost.Extensions;
 /// <summary>
 ///     Provides extension methods for configuring Liquibase database migrations in .NET Aspire orchestration.
 /// </summary>
+[ExcludeFromCodeCoverage]
 public static class LiquibaseExtensions
 {
     /// <summary>

--- a/src/AppDomain.AppHost/Extensions/UrlExtensions.cs
+++ b/src/AppDomain.AppHost/Extensions/UrlExtensions.cs
@@ -7,6 +7,7 @@ namespace AppDomain.AppHost.Extensions;
 /// <summary>
 /// Represents a parsed endpoint specification with scheme and optional port.
 /// </summary>
+[ExcludeFromCodeCoverage]
 internal record EndpointSpec(string Scheme, int? Port)
 {
     /// <summary>
@@ -15,6 +16,7 @@ internal record EndpointSpec(string Scheme, int? Port)
     public bool IsSchemeOnly => Port == null;
 }
 
+[ExcludeFromCodeCoverage]
 public static class UrlExtensions
 {
     /// <summary>

--- a/src/AppDomain.AppHost/GlobalSuppressions.cs
+++ b/src/AppDomain.AppHost/GlobalSuppressions.cs
@@ -1,6 +1,3 @@
 // Copyright (c) OrgName. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
-
-[assembly: ExcludeFromCodeCoverage]
 [assembly: SuppressMessage("Performance", "CA1873", Justification = "Logging argument evaluation cost acceptable for endpoint URL configuration")]

--- a/src/AppDomain.AppHost/GlobalUsings.cs
+++ b/src/AppDomain.AppHost/GlobalUsings.cs
@@ -1,1 +1,3 @@
 // Copyright (c) OrgName. All rights reserved.
+
+global using System.Diagnostics.CodeAnalysis;

--- a/src/AppDomain.BackOffice.Orleans/DependencyInjection.cs
+++ b/src/AppDomain.BackOffice.Orleans/DependencyInjection.cs
@@ -1,7 +1,5 @@
 // Copyright (c) OrgName. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace AppDomain.BackOffice.Orleans;
 
 /// <summary>

--- a/src/AppDomain.BackOffice.Orleans/GlobalSuppressions.cs
+++ b/src/AppDomain.BackOffice.Orleans/GlobalSuppressions.cs
@@ -1,6 +1,4 @@
 // Copyright (c) OrgName. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
-
 [assembly: SuppressMessage("Performance", "CA1873", Justification = "Logging argument evaluation cost acceptable for grain operation logging")]
 [assembly: SuppressMessage("Orleans", "ORLEANS0010", Justification = "Alias attributes not required for internal grain interfaces and state")]

--- a/src/AppDomain.BackOffice.Orleans/GlobalUsings.cs
+++ b/src/AppDomain.BackOffice.Orleans/GlobalUsings.cs
@@ -1,3 +1,4 @@
 // Copyright (c) OrgName. All rights reserved.
 
+global using System.Diagnostics.CodeAnalysis;
 global using AppDomain;

--- a/src/AppDomain.BackOffice.Orleans/Infrastructure/Extensions/OrleansExtensions.cs
+++ b/src/AppDomain.BackOffice.Orleans/Infrastructure/Extensions/OrleansExtensions.cs
@@ -8,6 +8,7 @@ namespace AppDomain.BackOffice.Orleans.Infrastructure.Extensions;
 /// <summary>
 ///     Provides extension methods for configuring Microsoft Orleans in the application.
 /// </summary>
+[ExcludeFromCodeCoverage]
 public static class OrleansExtensions
 {
     public const string SectionName = "Orleans";

--- a/src/AppDomain.BackOffice.Orleans/Invoices/Grains/InvoiceActor.cs
+++ b/src/AppDomain.BackOffice.Orleans/Invoices/Grains/InvoiceActor.cs
@@ -19,6 +19,7 @@ namespace AppDomain.BackOffice.Orleans.Invoices.Grains;
 /// <param name="invoiceState">The persistent state for grain metadata</param>
 /// <param name="messageBus">Wolverine message bus for commands/queries</param>
 /// <param name="logger">Logger instance</param>
+[ExcludeFromCodeCoverage]
 [GrainDirectory(GrainDirectoryName = OrleansExtensions.GrainDirectoryName)]
 public class InvoiceActor(
     ILogger<InvoiceActor> logger,


### PR DESCRIPTION
This pull request introduces code coverage exclusion for specific classes and records across the `AppDomain.AppHost` and `AppDomain.BackOffice.Orleans` projects. The main change is the addition of the `[ExcludeFromCodeCoverage]` attribute to extension classes and internal records, which signals to code coverage tools to ignore these types during coverage analysis. Additionally, the global usage of `System.Diagnostics.CodeAnalysis` is streamlined, and redundant assembly-level exclusions are removed.

Code coverage exclusion improvements:

* Added `[ExcludeFromCodeCoverage]` to `GrpcExtensions`, `LaunchProfileExtensions`, and `LiquibaseExtensions` classes in `src/AppDomain.AppHost/Extensions` to exclude them from code coverage reports. [[1]](diffhunk://#diff-a26dec4b291bb6138e1bd30ea36b96aafd948e4e10559da7cbc71322eeb81070R8) [[2]](diffhunk://#diff-ccef993d796b9980349579b87db7415eaeca36a68714436de6f9e6ffe0b5dfc6R11) [[3]](diffhunk://#diff-dc34544973132ca84355092ba17c320bea812ed109cc3eaa3a8ba79e2a36b66fR8)
* Applied `[ExcludeFromCodeCoverage]` to the `EndpointSpec` record and `UrlExtensions` class in `src/AppDomain.AppHost/Extensions/UrlExtensions.cs`. [[1]](diffhunk://#diff-f2df0e2f759864be7997cff2ec268293aa0439e9d243d9b835df3dbe25efcf0fR10) [[2]](diffhunk://#diff-f2df0e2f759864be7997cff2ec268293aa0439e9d243d9b835df3dbe25efcf0fR19)
* Added `[ExcludeFromCodeCoverage]` to the `OrleansExtensions` class in `src/AppDomain.BackOffice.Orleans/Infrastructure/Extensions/OrleansExtensions.cs`.
* Marked the `InvoiceActor` class with `[ExcludeFromCodeCoverage]` in `src/AppDomain.BackOffice.Orleans/Invoices/Grains/InvoiceActor.cs`.

Project structure and global using cleanup:

* Introduced global using of `System.Diagnostics.CodeAnalysis` in `GlobalUsings.cs` files for both `AppHost` and `BackOffice.Orleans` projects, and removed direct usages from individual files. [[1]](diffhunk://#diff-94d45e03f732f84a6b32f8e240b664647670eee63e3148ef42d0e6fcf4d40f82R2-R3) [[2]](diffhunk://#diff-fef92131f3b12836e1defc13a955a779b85174c0903eb8bb02099a117dc5ee54R3) [[3]](diffhunk://#diff-63f950672adc4caa8f025cb172b10ea6a77d9450fbea46c54c9ccaf695b1d746L3-L4) [[4]](diffhunk://#diff-c5f4b6509641aaae6c532521aa78a1e040c4a10c846562dc714a00bf670df67fL3-L4)
* Removed the assembly-level `[ExcludeFromCodeCoverage]` attribute from `GlobalSuppressions.cs` in `src/AppDomain.AppHost`, as coverage exclusion is now handled at the type level.…ses in AppHost and Orleans

Replace assembly-level attribute with class-level attributes on GrpcExtensions, LaunchProfileExtensions, LiquibaseExtensions, UrlExtensions, EndpointSpec, OrleansExtensions, InvoiceActor, and DependencyInjection.