### PR TITLE
Bump NuGet package dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,11 +1,11 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <AspireVersion>13.1.2</AspireVersion>
+    <AspireVersion>13.2.2</AspireVersion>
     <AspireAppHostSdkVersion>$(AspireVersion)</AspireAppHostSdkVersion>
-    <MicrosoftExtensionsVersion>10.0.3</MicrosoftExtensionsVersion>
+    <MicrosoftExtensionsVersion>10.0.6</MicrosoftExtensionsVersion>
     <!--#if (INCLUDE_ORLEANS) -->
-    <MicrosoftOrleansVersion>10.0.1</MicrosoftOrleansVersion>
+    <MicrosoftOrleansVersion>10.1.0</MicrosoftOrleansVersion>
     <!--#endif -->
     <OpenTelemetryVersion>1.15.0</OpenTelemetryVersion>
     <!--#if (INCLUDE_GRPC) -->
@@ -35,8 +35,8 @@
     <PackageVersion Include="Bogus" Version="35.6.5" />
     <PackageVersion Include="CloudNative.CloudEvents.Kafka" Version="2.8.0" />
     <PackageVersion Include="CloudNative.CloudEvents.SystemTextJson" Version="2.8.0" />
-    <PackageVersion Include="coverlet.collector" Version="8.0.0" />
-    <PackageVersion Include="Dapper" Version="2.1.66" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
+    <PackageVersion Include="Dapper" Version="2.1.72" />
     <PackageVersion Include="Fluid.Core" Version="2.31.0" />
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
@@ -48,8 +48,8 @@
     <PackageVersion Include="Grpc.Net.Client" Version="$(GrpcVersion)" />
     <PackageVersion Include="Grpc.Tools" Version="2.68.1" />
     <!--#endif -->
-    <PackageVersion Include="linq2db" Version="6.1.0" />
-    <PackageVersion Include="linq2db.Extensions" Version="6.1.0" />
+    <PackageVersion Include="linq2db" Version="6.2.1" />
+    <PackageVersion Include="linq2db.Extensions" Version="6.2.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="$(MicrosoftExtensionsVersion)" />
@@ -63,12 +63,12 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.3.0" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.5.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.3.0" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.3.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.5.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <!--#if (INCLUDE_ORLEANS) -->
     <PackageVersion Include="Microsoft.Orleans.Analyzers" Version="$(MicrosoftOrleansVersion)" />
     <PackageVersion Include="Microsoft.Orleans.Client" Version="$(MicrosoftOrleansVersion)" />
@@ -81,7 +81,7 @@
     <PackageVersion Include="Microsoft.Orleans.Dashboard" Version="$(MicrosoftOrleansVersion)" />
     <PackageVersion Include="Microsoft.Orleans.GrainDirectory.AzureStorage" Version="$(MicrosoftOrleansVersion)" />
     <!--#endif -->
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.103" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.202" />
     <PackageVersion Include="Momentum.Extensions" Version="$(MomentumVersion)" />
     <PackageVersion Include="Momentum.Extensions.Abstractions" Version="$(MomentumVersion)" />
     <PackageVersion Include="Momentum.Extensions.Messaging.Kafka" Version="$(MomentumVersion)" />
@@ -90,16 +90,16 @@
     <PackageVersion Include="Momentum.ServiceDefaults" Version="$(MomentumVersion)" />
     <PackageVersion Include="Momentum.ServiceDefaults.Api" Version="$(MomentumVersion)" />
     <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />
-    <PackageVersion Include="Npgsql" Version="10.0.1" />
+    <PackageVersion Include="Npgsql" Version="10.0.2" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="OneOf" Version="3.0.271" />
     <PackageVersion Include="OneOf.SourceGenerator" Version="3.0.271" />
-    <PackageVersion Include="Refit" Version="10.0.1" />
-    <PackageVersion Include="Refit.HttpClientFactory" Version="10.0.1" />
+    <PackageVersion Include="Refit" Version="10.1.6" />
+    <PackageVersion Include="Refit.HttpClientFactory" Version="10.1.6" />
     <PackageVersion Include="Refitter.MSBuild" Version="1.7.3" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryVersion)" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryVersion)" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="$(OpenTelemetryVersion)" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
     <!--#if (INCLUDE_GRPC) -->
     <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcCore" Version="1.0.0-beta.10" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.15.0-beta.1" />
@@ -107,22 +107,22 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="$(OpenTelemetryVersion)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="$(OpenTelemetryVersion)" />
     <PackageVersion Include="Riok.Mapperly" Version="4.3.1" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.12.52" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.14.0" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Serilog.Exceptions" Version="8.4.0" />
     <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
-    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.20.0.135146" />
-    <PackageVersion Include="Spectre.Console.Cli" Version="0.53.1" />
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.23.0.137933" />
+    <PackageVersion Include="Spectre.Console.Cli" Version="0.55.0" />
     <PackageVersion Include="System.Net.Http.Json" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageVersion Include="Testcontainers" Version="4.10.0" />
-    <PackageVersion Include="Testcontainers.Kafka" Version="4.10.0" />
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.10.0" />
-    <PackageVersion Include="WolverineFx" Version="5.17.0" />
+    <PackageVersion Include="Testcontainers" Version="4.11.0" />
+    <PackageVersion Include="Testcontainers.Kafka" Version="4.11.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.11.0" />
+    <PackageVersion Include="WolverineFx" Version="5.31.1" />
     <!--#if (USE_KAFKA) -->
-    <PackageVersion Include="WolverineFx.Kafka" Version="5.17.0" />
+    <PackageVersion Include="WolverineFx.Kafka" Version="5.31.1" />
     <!--#endif -->
-    <PackageVersion Include="WolverineFx.Postgresql" Version="5.17.0" />
+    <PackageVersion Include="WolverineFx.Postgresql" Version="5.31.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>

--- a/libs/Momentum/src/Momentum.Extensions.EventMarkdownGenerator/CopyTemplatesCommand.cs
+++ b/libs/Momentum/src/Momentum.Extensions.EventMarkdownGenerator/CopyTemplatesCommand.cs
@@ -23,7 +23,7 @@ public sealed class CopyTemplatesCommand : AsyncCommand<CopyTemplatesCommand.Set
         public bool Force { get; init; }
     }
 
-    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
         try
         {

--- a/libs/Momentum/src/Momentum.Extensions.EventMarkdownGenerator/GenerateCommand.cs
+++ b/libs/Momentum/src/Momentum.Extensions.EventMarkdownGenerator/GenerateCommand.cs
@@ -54,7 +54,7 @@ public sealed class GenerateCommand : AsyncCommand<GenerateCommand.Settings>
         public bool Verbose { get; init; }
     }
 
-    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
         try
         {


### PR DESCRIPTION
Updates Aspire 13.1.2 to 13.2.2, Microsoft.Extensions 10.0.3 to 10.0.6, Microsoft.Orleans 10.0.1 to 10.1.0, WolverineFx 5.17.0 to 5.31.1, plus patch bumps across Dapper, linq2db, Testcontainers, Refit, Npgsql, OpenTelemetry.Instrumentation.AspNetCore, Scalar, SonarAnalyzer, SourceLink, Microsoft.NET.Test.Sdk, and coverlet.collector.

Spectre.Console.Cli 0.53.1 to 0.55.0 changed AsyncCommand.ExecuteAsync visibility from public to protected, so CopyTemplatesCommand and GenerateCommand overrides are adjusted to match.