### PR TITLE
docs: add community standards (CONTRIBUTING, issue templates, PR template)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,225 @@
+# Contributing to Momentum .NET
+
+Thank you for your interest in contributing! Momentum .NET is a dual-purpose project — a **dotnet template** (`mmt`) that generates production-ready microservices solutions, and a set of **Momentum NuGet libraries** used by those solutions.
+
+## Table of Contents
+
+- [Project Structure](#project-structure)
+- [Prerequisites](#prerequisites)
+- [Development Setup](#development-setup)
+- [Types of Contributions](#types-of-contributions)
+- [Coding Conventions](#coding-conventions)
+- [Testing Requirements](#testing-requirements)
+- [Commit Messages](#commit-messages)
+- [Submitting a Pull Request](#submitting-a-pull-request)
+- [Getting Help](#getting-help)
+
+---
+
+## Project Structure
+
+```
+momentum/
+├── src/                         # Sample AppDomain application (template source)
+├── libs/Momentum/               # Standalone Momentum NuGet libraries
+│   ├── src/
+│   │   ├── Momentum.Extensions
+│   │   ├── Momentum.ServiceDefaults
+│   │   ├── Momentum.ServiceDefaults.Api
+│   │   ├── Momentum.Extensions.SourceGenerators
+│   │   └── Momentum.Extensions.Messaging.Kafka
+│   └── tests/
+├── tests/                       # AppDomain integration, E2E, and architecture tests
+├── infra/                       # Liquibase database migrations
+├── docs/                        # VitePress documentation site
+└── .template.config/            # dotnet new template configuration
+```
+
+Changes to **`libs/Momentum/`** affect the libraries published to NuGet.  
+Changes to everything else (especially `.template.config/` and `src/`) affect the `mmt` template.
+
+---
+
+## Prerequisites
+
+- [.NET 10 SDK](https://dotnet.microsoft.com/download)
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) — required for integration tests
+- [Bun](https://bun.sh/) — required for the documentation site
+- Git
+
+---
+
+## Development Setup
+
+### Working on the Template
+
+```bash
+# Install the template locally
+dotnet new install ./ --force
+
+# Generate a test solution using the installed template
+dotnet new mmt -n TestService --allow-scripts yes
+
+# Generate with locally built Momentum packages
+dotnet new mmt -n TestService --allow-scripts yes --local
+
+# Run the full template test suite
+./scripts/Run-TemplateTests.ps1
+
+# Run a specific test category
+./scripts/Run-TemplateTests.ps1 -Category component-isolation
+```
+
+Available test categories: `component-isolation`, `database-config`, `port-config`, `org-names`, `library-config`, `real-world-patterns`, `orleans-combinations`, `edge-cases`
+
+### Working on the Libraries
+
+```bash
+# Build all Momentum libraries
+cd libs/Momentum
+dotnet build Momentum.slnx
+
+# Run library tests
+dotnet test libs/Momentum/
+
+# Pack libraries to the local NuGet feed (enables --local template testing)
+dotnet pack libs/Momentum/src/<LibraryName> --configuration Release
+```
+
+### Running the Sample Application
+
+```bash
+# Start infrastructure (PostgreSQL + Kafka)
+docker-compose --profile db --profile messaging up -d
+
+# Start the Aspire-orchestrated application
+dotnet run --project src/AppDomain.AppHost
+# API:            https://localhost:8101 (REST), :8102 (gRPC)
+# Aspire Dashboard: https://localhost:18110
+
+# Start the documentation site
+cd docs && bun install && bun run dev
+# Documentation: http://localhost:8119
+```
+
+---
+
+## Types of Contributions
+
+### Bug Fixes
+
+- Open an issue using the appropriate bug report template before submitting a fix for a non-trivial bug.
+- Include a failing test that reproduces the issue when possible.
+
+### New Features
+
+- Open a feature request issue to discuss the change before implementing it.
+- Keep changes focused — one feature per PR.
+
+### Documentation
+
+- VitePress docs live in `docs/`. Run `bun run dev` inside `docs/` to preview locally.
+- Correct typos, improve clarity, and add missing examples.
+
+### Library Contributions
+
+- New library functionality belongs in `libs/Momentum/`.
+- Public APIs must include XML doc comments.
+- Use source generators where appropriate (see `Momentum.Extensions.SourceGenerators`).
+
+---
+
+## Coding Conventions
+
+- **Language**: C# 13 / .NET 10 with nullable reference types enabled.
+- **Style**: Enforced by `.editorconfig` and `AppDomain.ruleset`. Run `dotnet format` before committing.
+- **Architecture**: Follow Domain-Oriented Vertical Slice (CQRS + Event-Driven). Keep commands, queries, and events in their respective domain folders.
+- **Database migrations**: Each table in its own file under `tables/`. Constraints, indexes, and triggers stay in the same file as the table — never in separate constraint files.
+- **Events**: Use CloudEvents format with the `[EventTopic(...)]` attribute.
+
+---
+
+## Testing Requirements
+
+All PRs must maintain or improve test coverage. Run the full suite before opening a PR:
+
+```bash
+# Unit and architecture tests
+dotnet test
+
+# Integration tests (requires Docker)
+dotnet test tests/AppDomain.Tests/Integration/
+
+# End-to-end tests
+dotnet test tests/AppDomain.Tests.E2E/
+
+# Template validation (runs all template combinations)
+./scripts/Run-TemplateTests.ps1
+```
+
+For library changes, also run:
+
+```bash
+dotnet test libs/Momentum/
+```
+
+---
+
+## Commit Messages
+
+Follow the [Conventional Commits](https://www.conventionalcommits.org/) format:
+
+```
+<type>(<scope>): <short description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+**Types**: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `perf`
+
+**Scopes**: match the changed area — e.g., `template`, `extensions`, `service-defaults`, `kafka`, `generators`, `docs`, `ci`
+
+**Examples**:
+
+```bash
+feat(template): add --bff flag for BFF component generation
+fix(extensions): resolve null reference in Result<T>.Map when value is empty
+docs(guide): add troubleshooting section for Kafka connection issues
+test(generators): add snapshot tests for DbCommand source generator
+chore(ci): upgrade SonarQube action to v4
+```
+
+---
+
+## Submitting a Pull Request
+
+1. Fork the repository and create a branch from `main`:
+   ```bash
+   git checkout -b fix/your-fix-name
+   ```
+
+2. Make your changes and ensure all tests pass.
+
+3. Run `dotnet format` to enforce code style.
+
+4. Push your branch and open a PR against `main`. Fill out the PR template.
+
+5. The CI pipeline will run:
+   - Build and test (`dotnet build`, `dotnet test`)
+   - SonarCloud quality analysis
+   - Template validation (on template-related changes)
+
+6. Address any review feedback. Push additional commits to the same branch — do not force-push after a review has started.
+
+7. Once approved, a maintainer will squash-merge your PR.
+
+---
+
+## Getting Help
+
+- **Docs**: [Architecture overview](../docs/arch/), [Development setup](../docs/guide/dev-setup.md), [First contribution guide](../docs/guide/first-contribution.md)
+- **Issues**: Search existing issues before opening a new one.
+- **Security vulnerabilities**: See [SECURITY.md](SECURITY.md) — do not open a public issue.
+- **Code of Conduct**: This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md).

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -80,10 +80,10 @@ cd libs/Momentum
 dotnet build Momentum.slnx
 
 # Run library tests
-dotnet test libs/Momentum/
+dotnet test Momentum.slnx
 
 # Pack libraries to the local NuGet feed (enables --local template testing)
-dotnet pack libs/Momentum/src/<LibraryName> --configuration Release
+dotnet pack src/<LibraryName> --configuration Release
 ```
 
 ### Running the Sample Application

--- a/.github/ISSUE_TEMPLATE/bug-momentum-library.yml
+++ b/.github/ISSUE_TEMPLATE/bug-momentum-library.yml
@@ -1,0 +1,90 @@
+name: "Bug Report: Momentum Library"
+description: Report a bug in one of the Momentum NuGet libraries (Extensions, ServiceDefaults, Kafka, SourceGenerators, etc.)
+labels: ["bug", "momentum-library"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug in the Momentum libraries. Please fill out the sections below so we can reproduce and fix the issue quickly.
+
+  - type: dropdown
+    id: library
+    attributes:
+      label: Affected Library
+      description: Which Momentum library is affected?
+      options:
+        - Momentum.Extensions
+        - Momentum.ServiceDefaults
+        - Momentum.ServiceDefaults.Api
+        - Momentum.Extensions.SourceGenerators
+        - Momentum.Extensions.Messaging.Kafka
+        - Not sure / multiple libraries
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Library Version
+      description: Which version of the library are you using? (check your `Directory.Packages.props` or `.csproj`)
+      placeholder: "e.g. 1.2.3"
+    validations:
+      required: true
+
+  - type: input
+    id: dotnet-version
+    attributes:
+      label: .NET Version
+      description: Output of `dotnet --version`
+      placeholder: "e.g. 10.0.100"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear description of what the bug is.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: Minimal steps to reproduce the behavior.
+      placeholder: |
+        1. Register `...` in DI
+        2. Call `...`
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened? Include exception messages and stack traces if applicable.
+    validations:
+      required: true
+
+  - type: textarea
+    id: code
+    attributes:
+      label: Minimal Reproduction Code
+      description: A minimal code snippet or link to a repository that reproduces the issue.
+      render: csharp
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other relevant information (runtime environment, OS, related issues, etc.)

--- a/.github/ISSUE_TEMPLATE/bug-momentum-template.yml
+++ b/.github/ISSUE_TEMPLATE/bug-momentum-template.yml
@@ -1,0 +1,93 @@
+name: "Bug Report: Momentum Template (mmt)"
+description: Report a bug with the `dotnet new mmt` template — generation failures, incorrect output, missing files, or post-setup issues.
+labels: ["bug", "momentum-template"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a template bug. Please include the exact `dotnet new mmt` command you ran and the template version so we can reproduce the issue.
+
+  - type: input
+    id: template-version
+    attributes:
+      label: Template Version
+      description: Output of `dotnet new mmt --version` or the NuGet package version.
+      placeholder: "e.g. 1.2.3"
+    validations:
+      required: true
+
+  - type: input
+    id: dotnet-version
+    attributes:
+      label: .NET SDK Version
+      description: Output of `dotnet --version`
+      placeholder: "e.g. 10.0.100"
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      placeholder: "e.g. macOS 15.2, Windows 11, Ubuntu 24.04"
+    validations:
+      required: true
+
+  - type: textarea
+    id: command
+    attributes:
+      label: Template Command Used
+      description: The exact `dotnet new mmt` command that triggered the issue.
+      placeholder: "dotnet new mmt -n MyService --api --kafka --allow-scripts yes"
+      render: bash
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: What went wrong? Describe the problem clearly.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect the template to generate or do?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened? Include error messages and relevant file contents.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected Area
+      description: Which part of the template is affected?
+      options:
+        - Template generation (dotnet new)
+        - Post-setup script
+        - Generated project structure
+        - Generated code / compilation errors
+        - Conditional component (API, BackOffice, Orleans, Aspire, Kafka)
+        - Database / Liquibase migrations
+        - NuGet package references
+        - Documentation site generation
+        - Local (--local) development mode
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other relevant details (CI environment, related issues, workarounds tried, etc.)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security Vulnerability
+    url: https://github.com/vgmello/momentum/blob/main/.github/SECURITY.md
+    about: Please report security vulnerabilities privately — see SECURITY.md for instructions.
+  - name: Documentation
+    url: https://github.com/vgmello/momentum/blob/main/docs
+    about: Check the documentation before opening an issue — your question may already be answered.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,55 @@
+name: Feature Request
+description: Suggest a new feature or improvement for the Momentum template or libraries.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for suggesting a new feature! Please describe what you'd like and why it would be valuable.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of the project does this feature request apply to?
+      options:
+        - Momentum Template (mmt)
+        - Momentum.Extensions library
+        - Momentum.ServiceDefaults library
+        - Momentum.ServiceDefaults.Api library
+        - Momentum.Extensions.SourceGenerators library
+        - Momentum.Extensions.Messaging.Kafka library
+        - Documentation
+        - CI/CD / tooling
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / Motivation
+      description: What problem are you trying to solve? Why is this needed?
+      placeholder: "When I do X, I have to manually Y every time, which is error-prone..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the feature you'd like. Be as specific as possible.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Have you considered any alternative solutions or workarounds?
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context, mockups, code examples, or related issues.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+## Summary
+
+<!-- Describe the change and why it's needed. Link related issues with "Closes #123" or "Fixes #123". -->
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Refactor / internal improvement
+- [ ] Documentation update
+- [ ] CI / tooling change
+
+## Area
+
+- [ ] Momentum Template (`mmt`)
+- [ ] Momentum Library (`libs/Momentum/`)
+- [ ] Sample application (`src/`, `tests/`)
+- [ ] Documentation (`docs/`)
+- [ ] Infrastructure / CI
+
+## Testing
+
+- [ ] Unit tests added / updated
+- [ ] Integration tests added / updated (requires Docker)
+- [ ] Template validation passes (`./scripts/Run-TemplateTests.ps1`)
+- [ ] Manual testing completed
+- [ ] All existing tests pass (`dotnet test`)
+
+## Checklist
+
+- [ ] Code formatted (`dotnet format`)
+- [ ] No new compiler warnings
+- [ ] Public APIs have XML doc comments (library changes only)
+- [ ] Database migrations follow the project conventions (one table per file, constraints in same file)
+- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
+- [ ] Documentation updated if behavior changed


### PR DESCRIPTION
## Summary

Adds GitHub community health files to the Momentum repository, covering both the `mmt` dotnet template and the Momentum NuGet libraries.

- **CONTRIBUTING.md** — specialized contributing guide covering template development workflow, library development workflow, coding conventions (vertical slice / CQRS patterns, Liquibase rules, conventional commits), testing requirements, and PR process.
- **Issue templates**:
  - `bug-momentum-library.yml` — for bugs in Momentum NuGet libraries (Extensions, ServiceDefaults, Kafka, SourceGenerators)
  - `bug-momentum-template.yml` — for bugs in the `dotnet new mmt` template (generation failures, incorrect output, post-setup issues)
  - `feature-request.yml` — for new features/improvements across both areas
  - `config.yml` — disables blank issues and links to SECURITY.md and docs
- **PULL_REQUEST_TEMPLATE.md** — checklist covering change type, affected area, testing (unit, integration, template validation), formatting, and project conventions.

## Test plan
- [ ] Verify issue templates render correctly on GitHub
- [ ] Verify PR template pre-fills when opening a new PR
- [ ] Verify CONTRIBUTING.md appears in the repository's community health file checklist

Closes [LOC-14](mention://issue/3ad76c58-0fab-4e18-988c-7716191cf5d6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)