### PR TITLE
fix: resolve AmbiguousMatchException with Grpc.AspNetCore 2.80.0+

### DIFF
--- a/libs/Momentum/src/Momentum.ServiceDefaults.Api/GrpcRegistrationExtensions.cs
+++ b/libs/Momentum/src/Momentum.ServiceDefaults.Api/GrpcRegistrationExtensions.cs
@@ -18,8 +18,15 @@ public static class GrpcRegistrationExtensions
 {
     private const BindingFlags STATIC_METHODS = BindingFlags.Public | BindingFlags.Static;
 
-    private static readonly MethodInfo GrpcMapServiceMethod = typeof(GrpcEndpointRouteBuilderExtensions)
-        .GetMethod(nameof(GrpcEndpointRouteBuilderExtensions.MapGrpcService), STATIC_METHODS)!;
+    // Explicitly select the single-parameter overload to avoid AmbiguousMatchException
+    // when Grpc.AspNetCore introduces additional MapGrpcService overloads (e.g. v2.80.0+)
+    private static readonly MethodInfo GrpcMapServiceMethod =
+        typeof(GrpcEndpointRouteBuilderExtensions)
+            .GetMethods(STATIC_METHODS)
+            .Single(m => m.Name == nameof(GrpcEndpointRouteBuilderExtensions.MapGrpcService)
+                      && m.IsGenericMethodDefinition
+                      && m.GetParameters().Length == 1
+                      && m.GetParameters()[0].ParameterType == typeof(IEndpointRouteBuilder));
 
     /// <summary>
     ///     Maps all gRPC services found in the specified assembly to endpoints.


### PR DESCRIPTION
## Summary

- `Grpc.AspNetCore` v2.80.0 introduced a new `MapGrpcService` overload (as part of implementing `GrpcServiceEndpointConventionBuilder.Finally`), which causes `GetMethod()` to throw `System.Reflection.AmbiguousMatchException` in `GrpcRegistrationExtensions` at type initialization time
- All integration tests in `AppDomain.Tests` fail with this error when running against the newer gRPC version (Dependabot PR #203)
- Fix: use `GetMethods().Single()` with explicit filtering to select the single-parameter `(IEndpointRouteBuilder)` overload — backward-compatible with 2.67.0 and forward-compatible with 2.80.0+

## Test plan

- [ ] CI should pass on this PR with existing gRPC 2.67.0
- [ ] After merging this PR, Dependabot PR #203 (bumping Grpc.AspNetCore to 2.80.0) should also pass CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)