### PR TITLE
Fix local NuGet feed packages not being deleted (CleanOldPackages)

### DIFF
--- a/libs/Momentum/Directory.Build.targets
+++ b/libs/Momentum/Directory.Build.targets
@@ -8,7 +8,7 @@
             <!-- Use regex to match only this exact PackageId followed by a version (digit),
                  avoiding deletion of similarly-prefixed packages (e.g. Momentum.ServiceDefaults
                  must not delete Momentum.ServiceDefaults.Api) -->
-            <_FeedCandidates Include="$(MSBuildThisFileDirectory).local/nuget/$(PackageId).*.*upkg"/>
+            <_FeedCandidates Include="$(MSBuildThisFileDirectory).local/nuget/$(PackageId.ToLowerInvariant())/**/*.*upkg"/>
             <OldPackagesToDelete Include="@(_FeedCandidates)"
                 Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('%(Filename)', '$(_PackageIdPattern)'))" />
         </ItemGroup>

--- a/libs/Momentum/Directory.Build.targets
+++ b/libs/Momentum/Directory.Build.targets
@@ -1,14 +1,16 @@
 <Project>
     <Target Name="CleanOldPackages" BeforeTargets="Build;Clean" Condition=" '$(IsPackable)' == 'true' and '$(Configuration)' == 'Debug' ">
         <PropertyGroup>
-            <_PackageIdPattern>^$([System.Text.RegularExpressions.Regex]::Escape($(PackageId)))\.\d</_PackageIdPattern>
+            <!-- Use [.][0-9] instead of \.\d — MSBuild converts backslashes to forward slashes on
+                 non-Windows, which corrupts regex escape sequences like \. and \d. -->
+            <_PackageIdPattern>^$([System.Text.RegularExpressions.Regex]::Escape($(PackageId)))[.][0-9]</_PackageIdPattern>
         </PropertyGroup>
         <ItemGroup>
             <OldPackagesToDelete Include="$(TargetDir)../*.*upkg"/>
             <!-- Use regex to match only this exact PackageId followed by a version (digit),
                  avoiding deletion of similarly-prefixed packages (e.g. Momentum.ServiceDefaults
                  must not delete Momentum.ServiceDefaults.Api) -->
-            <_FeedCandidates Include="$(MSBuildThisFileDirectory).local/nuget/$(PackageId.ToLowerInvariant())/**/*.*upkg"/>
+            <_FeedCandidates Include="$(MSBuildThisFileDirectory).local/nuget/$(PackageId).*.*upkg"/>
             <OldPackagesToDelete Include="@(_FeedCandidates)"
                 Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('%(Filename)', '$(_PackageIdPattern)'))" />
         </ItemGroup>


### PR DESCRIPTION
## Summary

- **Root cause (corrected):** The local NuGet feed at `.local/nuget/` is a flat folder — packages are stored directly as `Momentum.Extensions.1000.0.0.nupkg`, not in a v3 hierarchical structure. The `CleanOldPackages` target was silently broken on macOS/Linux because MSBuild converts backslashes to forward slashes on non-Windows platforms: `\.\d` in the regex pattern became `/./d`, so the `IsMatch` condition never matched any filename and no packages were ever deleted.
- **Actual fix:** Changed `_PackageIdPattern` to use `[.][0-9]` instead of `\.\d` (avoids backslash escapes entirely). Also restored the glob to `$(PackageId).*.*upkg` — the previous attempt used `$(PackageId.ToLowerInvariant())/**/*.*upkg` (hierarchical), which matched nothing because the feed is flat.

## Test plan

- [x] Build `libs/Momentum/Momentum.slnx` in Debug configuration — succeeds with 0 errors, 0 warnings
- [x] Simulated old package accumulation by placing `Momentum.Extensions.0.9.9.nupkg` and `Momentum.ServiceDefaults.0.9.9.nupkg` directly in `.local/nuget/`
- [x] Rebuilt — `CleanOldPackages` deleted both old packages
- [x] Confirmed current-version packages (`*.1000.0.0.nupkg`) are untouched
- [x] Confirmed no cross-deletion: `Momentum.ServiceDefaults.Api.1000.0.0.nupkg` was not deleted when cleaning `Momentum.ServiceDefaults`

🤖 Generated with [Claude Code](https://claude.com/claude-code)