### PR TITLE
Remove RefitterSkipValidation workaround (Refitter.MSBuild 2.0.0)

### DIFF
--- a/tests/AppDomain.Tests.E2E/AppDomain.Tests.E2E.csproj
+++ b/tests/AppDomain.Tests.E2E/AppDomain.Tests.E2E.csproj
@@ -4,9 +4,6 @@
         <IsTestProject>true</IsTestProject>
         <IsPackable>false</IsPackable>
         <RefitterNoLogging>true</RefitterNoLogging>
-        <!-- Refitter 1.7.3 bundles Microsoft.OpenApi v1.6 for validation, which doesn't support OpenAPI 3.1.
-             NSwag (used for actual generation) handles 3.1 fine. Skip validation until Refitter upgrades. -->
-        <RefitterSkipValidation>true</RefitterSkipValidation>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary

- `Refitter.MSBuild` was already bumped to `2.0.0` in `Directory.Packages.props`
- Removes the `<RefitterSkipValidation>true</RefitterSkipValidation>` workaround and its comment from `AppDomain.Tests.E2E.csproj` — the workaround was needed for v1.7.3 (which bundled `Microsoft.OpenApi v1.6` that lacked OpenAPI 3.1 support); v2.0.0 resolves this

## Test plan

- [ ] Build `AppDomain.slnx` to confirm no compilation errors
- [ ] Run `dotnet test tests/AppDomain.Tests.E2E/` to confirm E2E tests still pass with OpenAPI validation enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)