### PR TITLE
Bump NSubstitute to 6.0.0, fix nullable-API test breaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project are documented in this file, grouped by date
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2026-07-17]
+
+### Changed
+
+- **Deps**: bumped `NSubstitute` from `5.3.0` to `6.0.0` (major). Fixed three test files
+  (`CreateCashierCommandHandlerTests`, `UpdateCashierCommandHandlerTests`, `CreateInvoiceCommandHandlerTests`)
+  that cast `CallInfo`'s indexer directly (`(T)x[0]`), which no longer compiles under 6.0's nullable-annotated
+  public API — switched to the null-safe `x.ArgAt<T>(0)` extension instead.
+
+### Skipped
+
+- **Deps**: `Refitter.MSBuild` `2.0.0` → `2.1.0` was left in place — 2.1.0 refactored the MSBuild task itself
+  (upstream decoupled the CLI binary from the task) and fails code generation locally with
+  `MissingMethodException: System.Text.ValueStringBuilder.AsSpan()`. Needs an upstream fix before retrying.
+
 ## [2026-07-16]
 
 ### Changed

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -97,7 +97,7 @@
     <PackageVersion Include="Momentum.ServiceDefaults.Api" Version="$(MomentumVersion)" />
     <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />
     <PackageVersion Include="Npgsql" Version="10.0.3" />
-    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="NSubstitute" Version="6.0.0" />
     <PackageVersion Include="OneOf" Version="3.0.271" />
     <PackageVersion Include="OneOf.SourceGenerator" Version="3.0.271" />
     <PackageVersion Include="Refit" Version="13.1.0" />

--- a/tests/AppDomain.Tests/Unit/Cashier/CreateCashierCommandHandlerTests.cs
+++ b/tests/AppDomain.Tests/Unit/Cashier/CreateCashierCommandHandlerTests.cs
@@ -18,10 +18,10 @@ public class CreateCashierCommandHandlerTests
         messagingMock.InvokeCommandAsync(Arg.Any<CreateCashierCommandHandler.DbCommand>(), Arg.Any<CancellationToken>())
             .Returns(x => new AppDomain.Cashiers.Data.Entities.Cashier
             {
-                TenantId = ((CreateCashierCommandHandler.DbCommand)x[0]).Cashier.TenantId,
-                CashierId = ((CreateCashierCommandHandler.DbCommand)x[0]).Cashier.CashierId,
-                Name = ((CreateCashierCommandHandler.DbCommand)x[0]).Cashier.Name,
-                Email = ((CreateCashierCommandHandler.DbCommand)x[0]).Cashier.Email,
+                TenantId = x.ArgAt<CreateCashierCommandHandler.DbCommand>(0).Cashier.TenantId,
+                CashierId = x.ArgAt<CreateCashierCommandHandler.DbCommand>(0).Cashier.CashierId,
+                Name = x.ArgAt<CreateCashierCommandHandler.DbCommand>(0).Cashier.Name,
+                Email = x.ArgAt<CreateCashierCommandHandler.DbCommand>(0).Cashier.Email,
                 CreatedDateUtc = DateTime.UtcNow,
                 UpdatedDateUtc = DateTime.UtcNow,
                 Version = 12345 // Some mock xmin value
@@ -65,10 +65,10 @@ public class CreateCashierCommandHandlerTests
         messagingMock.InvokeCommandAsync(Arg.Any<CreateCashierCommandHandler.DbCommand>(), Arg.Any<CancellationToken>())
             .Returns(x => new AppDomain.Cashiers.Data.Entities.Cashier
             {
-                TenantId = ((CreateCashierCommandHandler.DbCommand)x[0]).Cashier.TenantId,
-                CashierId = ((CreateCashierCommandHandler.DbCommand)x[0]).Cashier.CashierId,
-                Name = ((CreateCashierCommandHandler.DbCommand)x[0]).Cashier.Name,
-                Email = ((CreateCashierCommandHandler.DbCommand)x[0]).Cashier.Email,
+                TenantId = x.ArgAt<CreateCashierCommandHandler.DbCommand>(0).Cashier.TenantId,
+                CashierId = x.ArgAt<CreateCashierCommandHandler.DbCommand>(0).Cashier.CashierId,
+                Name = x.ArgAt<CreateCashierCommandHandler.DbCommand>(0).Cashier.Name,
+                Email = x.ArgAt<CreateCashierCommandHandler.DbCommand>(0).Cashier.Email,
                 CreatedDateUtc = DateTime.UtcNow,
                 UpdatedDateUtc = DateTime.UtcNow,
                 Version = 12345 // Some mock xmin value

--- a/tests/AppDomain.Tests/Unit/Cashier/UpdateCashierCommandHandlerTests.cs
+++ b/tests/AppDomain.Tests/Unit/Cashier/UpdateCashierCommandHandlerTests.cs
@@ -21,10 +21,10 @@ public class UpdateCashierCommandHandlerTests
         messagingMock.InvokeCommandAsync(Arg.Any<UpdateCashierCommandHandler.DbCommand>(), Arg.Any<CancellationToken>())
             .Returns(x => new CashierEntity
             {
-                TenantId = ((UpdateCashierCommandHandler.DbCommand)x[0]).TenantId,
-                CashierId = ((UpdateCashierCommandHandler.DbCommand)x[0]).CashierId,
-                Name = ((UpdateCashierCommandHandler.DbCommand)x[0]).Name,
-                Email = ((UpdateCashierCommandHandler.DbCommand)x[0]).Email,
+                TenantId = x.ArgAt<UpdateCashierCommandHandler.DbCommand>(0).TenantId,
+                CashierId = x.ArgAt<UpdateCashierCommandHandler.DbCommand>(0).CashierId,
+                Name = x.ArgAt<UpdateCashierCommandHandler.DbCommand>(0).Name,
+                Email = x.ArgAt<UpdateCashierCommandHandler.DbCommand>(0).Email,
                 CreatedDateUtc = DateTime.UtcNow,
                 UpdatedDateUtc = DateTime.UtcNow,
                 Version = 2 // Version should be incremented after update
@@ -99,9 +99,9 @@ public class UpdateCashierCommandHandlerTests
         messagingMock.InvokeCommandAsync(Arg.Any<UpdateCashierCommandHandler.DbCommand>(), Arg.Any<CancellationToken>())
             .Returns(x => new CashierEntity
             {
-                TenantId = ((UpdateCashierCommandHandler.DbCommand)x[0]).TenantId,
-                CashierId = ((UpdateCashierCommandHandler.DbCommand)x[0]).CashierId,
-                Name = ((UpdateCashierCommandHandler.DbCommand)x[0]).Name,
+                TenantId = x.ArgAt<UpdateCashierCommandHandler.DbCommand>(0).TenantId,
+                CashierId = x.ArgAt<UpdateCashierCommandHandler.DbCommand>(0).CashierId,
+                Name = x.ArgAt<UpdateCashierCommandHandler.DbCommand>(0).Name,
                 Email = "Not Updated", // When email is null in command, it should remain unchanged (original value)
                 CreatedDateUtc = DateTime.UtcNow,
                 UpdatedDateUtc = DateTime.UtcNow,

--- a/tests/AppDomain.Tests/Unit/Invoices/CreateInvoiceCommandHandlerTests.cs
+++ b/tests/AppDomain.Tests/Unit/Invoices/CreateInvoiceCommandHandlerTests.cs
@@ -21,14 +21,14 @@ public class CreateInvoiceCommandHandlerTests
         messagingMock.InvokeCommandAsync(Arg.Any<CreateInvoiceCommandHandler.DbCommand>(), Arg.Any<CancellationToken>())
             .Returns(x => new AppDomain.Invoices.Data.Entities.Invoice
             {
-                TenantId = ((CreateInvoiceCommandHandler.DbCommand)x[0]).Invoice.TenantId,
-                InvoiceId = ((CreateInvoiceCommandHandler.DbCommand)x[0]).Invoice.InvoiceId,
-                Name = ((CreateInvoiceCommandHandler.DbCommand)x[0]).Invoice.Name,
+                TenantId = x.ArgAt<CreateInvoiceCommandHandler.DbCommand>(0).Invoice.TenantId,
+                InvoiceId = x.ArgAt<CreateInvoiceCommandHandler.DbCommand>(0).Invoice.InvoiceId,
+                Name = x.ArgAt<CreateInvoiceCommandHandler.DbCommand>(0).Invoice.Name,
                 Status = nameof(InvoiceStatus.Draft),
-                Amount = ((CreateInvoiceCommandHandler.DbCommand)x[0]).Invoice.Amount,
-                Currency = ((CreateInvoiceCommandHandler.DbCommand)x[0]).Invoice.Currency,
-                DueDate = ((CreateInvoiceCommandHandler.DbCommand)x[0]).Invoice.DueDate,
-                CashierId = ((CreateInvoiceCommandHandler.DbCommand)x[0]).Invoice.CashierId,
+                Amount = x.ArgAt<CreateInvoiceCommandHandler.DbCommand>(0).Invoice.Amount,
+                Currency = x.ArgAt<CreateInvoiceCommandHandler.DbCommand>(0).Invoice.Currency,
+                DueDate = x.ArgAt<CreateInvoiceCommandHandler.DbCommand>(0).Invoice.DueDate,
+                CashierId = x.ArgAt<CreateInvoiceCommandHandler.DbCommand>(0).Invoice.CashierId,
                 CreatedDateUtc = DateTime.UtcNow,
                 UpdatedDateUtc = DateTime.UtcNow,
                 Version = 1 // Initial version for new entity
@@ -81,14 +81,14 @@ public class CreateInvoiceCommandHandlerTests
         messagingMock.InvokeCommandAsync(Arg.Any<CreateInvoiceCommandHandler.DbCommand>(), Arg.Any<CancellationToken>())
             .Returns(x => new AppDomain.Invoices.Data.Entities.Invoice
             {
-                TenantId = ((CreateInvoiceCommandHandler.DbCommand)x[0]).Invoice.TenantId,
-                InvoiceId = ((CreateInvoiceCommandHandler.DbCommand)x[0]).Invoice.InvoiceId,
-                Name = ((CreateInvoiceCommandHandler.DbCommand)x[0]).Invoice.Name,
+                TenantId = x.ArgAt<CreateInvoiceCommandHandler.DbCommand>(0).Invoice.TenantId,
+                InvoiceId = x.ArgAt<CreateInvoiceCommandHandler.DbCommand>(0).Invoice.InvoiceId,
+                Name = x.ArgAt<CreateInvoiceCommandHandler.DbCommand>(0).Invoice.Name,
                 Status = nameof(InvoiceStatus.Draft),
-                Amount = ((CreateInvoiceCommandHandler.DbCommand)x[0]).Invoice.Amount,
-                Currency = ((CreateInvoiceCommandHandler.DbCommand)x[0]).Invoice.Currency,
-                DueDate = ((CreateInvoiceCommandHandler.DbCommand)x[0]).Invoice.DueDate,
-                CashierId = ((CreateInvoiceCommandHandler.DbCommand)x[0]).Invoice.CashierId,
+                Amount = x.ArgAt<CreateInvoiceCommandHandler.DbCommand>(0).Invoice.Amount,
+                Currency = x.ArgAt<CreateInvoiceCommandHandler.DbCommand>(0).Invoice.Currency,
+                DueDate = x.ArgAt<CreateInvoiceCommandHandler.DbCommand>(0).Invoice.DueDate,
+                CashierId = x.ArgAt<CreateInvoiceCommandHandler.DbCommand>(0).Invoice.CashierId,
                 CreatedDateUtc = DateTime.UtcNow,
                 UpdatedDateUtc = DateTime.UtcNow,
                 Version = 1 // Initial version for new entity
@@ -117,14 +117,14 @@ public class CreateInvoiceCommandHandlerTests
         messagingMock.InvokeCommandAsync(Arg.Any<CreateInvoiceCommandHandler.DbCommand>(), Arg.Any<CancellationToken>())
             .Returns(x => new AppDomain.Invoices.Data.Entities.Invoice
             {
-                TenantId = ((CreateInvoiceCommandHandler.DbCommand)x[0]).Invoice.TenantId,
-                InvoiceId = ((CreateInvoiceCommandHandler.DbCommand)x[0]).Invoice.InvoiceId,
-                Name = ((CreateInvoiceCommandHandler.DbCommand)x[0]).Invoice.Name,
+                TenantId = x.ArgAt<CreateInvoiceCommandHandler.DbCommand>(0).Invoice.TenantId,
+                InvoiceId = x.ArgAt<CreateInvoiceCommandHandler.DbCommand>(0).Invoice.InvoiceId,
+                Name = x.ArgAt<CreateInvoiceCommandHandler.DbCommand>(0).Invoice.Name,
                 Status = nameof(InvoiceStatus.Draft),
-                Amount = ((CreateInvoiceCommandHandler.DbCommand)x[0]).Invoice.Amount,
-                Currency = ((CreateInvoiceCommandHandler.DbCommand)x[0]).Invoice.Currency,
-                DueDate = ((CreateInvoiceCommandHandler.DbCommand)x[0]).Invoice.DueDate,
-                CashierId = ((CreateInvoiceCommandHandler.DbCommand)x[0]).Invoice.CashierId,
+                Amount = x.ArgAt<CreateInvoiceCommandHandler.DbCommand>(0).Invoice.Amount,
+                Currency = x.ArgAt<CreateInvoiceCommandHandler.DbCommand>(0).Invoice.Currency,
+                DueDate = x.ArgAt<CreateInvoiceCommandHandler.DbCommand>(0).Invoice.DueDate,
+                CashierId = x.ArgAt<CreateInvoiceCommandHandler.DbCommand>(0).Invoice.CashierId,
                 CreatedDateUtc = DateTime.UtcNow,
                 UpdatedDateUtc = DateTime.UtcNow,
                 Version = 1 // Initial version for new entity


### PR DESCRIPTION
## Summary
- Bumps `NSubstitute` `5.3.0` → `6.0.0` (major). Fixes the `(T)x[0]` CallInfo indexer cast pattern in 3 test files that no longer compiles under 6.0's nullable-annotated public API, switching to the null-safe `x.ArgAt<T>(0)` extension.
- Evaluated `Refitter.MSBuild` `2.0.0` → `2.1.0` but reverted: 2.1.0 refactored the MSBuild task itself and throws `MissingMethodException: System.Text.ValueStringBuilder.AsSpan()` during code generation. Left at 2.0.0 pending an upstream fix.

Supersedes/consolidates:
- #276 (testing group bump — Testcontainers part already on `main`; NSubstitute part applied here)
- #286 (NSubstitute 5.3.0 → 6.0.0 — applied here)
- #281 (api-client group — Refit.HttpClientFactory part already on `main`; Refitter.MSBuild part evaluated and skipped, see above)
- #285 (Refitter.MSBuild 2.0.0 → 2.1.0 — evaluated and skipped, see above)

## Test plan
- [x] `dotnet build AppDomain.slnx` — succeeds
- [x] `dotnet test tests/AppDomain.Tests` (unit, excl. Integration) — 160 passed
- [x] `dotnet test libs/Momentum/tests/Momentum.Extensions.Tests` — 341 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)