### PR TITLE
Fix event topic pluralization and domain/subdomain dedupe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project are documented in this file, grouped by date
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2026-07-18]
+
+### Fixed
+
+- **EventMarkdownGenerator**: `Pluralize()` no longer mangles past-tense/participle words (e.g.
+  `"reservation-created"` → `"reservation-createds"`) — words ending in `-ed` are now left unchanged, except
+  for a small set of genuine `-ed` nouns (`bed`, `seed`, `speed`, ...).
+- **EventMarkdownGenerator**: topic fallback (when `Topic` isn't set) now derives from the pluralized entity
+  name instead of the event name.
+- **EventMarkdownGenerator**: 22 event-doc scenario baselines regenerated to drop the bad pluralization they
+  had baked in (`payment-processeds` → `payment-processed`, etc); `docs/events/events-sidebar.json`
+  duplicate entries removed as a byproduct of regeneration.
+
+### Added
+
+- **EventTopicAttribute**: new `CollapseTopicOnDomain` property (default `true`) — drops the topic segment
+  from the fully-qualified topic name when it exactly duplicates the domain[.subdomain] path (e.g. domain
+  `"orders"` + topic `"orders"` → `"orders.v1"` instead of `"orders.orders.v1"`); set to `false` to always
+  keep both segments.
+
 ## [2026-07-17]
 
 ### Changed

--- a/docs/events/events-sidebar.json
+++ b/docs/events/events-sidebar.json
@@ -30,26 +30,8 @@
         "collapsed": false
       },
       {
-        "text": "Cashier Created",
-        "link": "/AppDomain.Cashiers.Contracts.IntegrationEvents.CashierCreated",
-        "items": [],
-        "collapsed": false
-      },
-      {
         "text": "Cashier Deleted",
         "link": "/AppDomain.Cashiers.Contracts.IntegrationEvents.CashierDeleted",
-        "items": [],
-        "collapsed": false
-      },
-      {
-        "text": "Cashier Deleted",
-        "link": "/AppDomain.Cashiers.Contracts.IntegrationEvents.CashierDeleted",
-        "items": [],
-        "collapsed": false
-      },
-      {
-        "text": "Cashier Updated",
-        "link": "/AppDomain.Cashiers.Contracts.IntegrationEvents.CashierUpdated",
         "items": [],
         "collapsed": false
       },
@@ -73,18 +55,6 @@
         "collapsed": false
       },
       {
-        "text": "Invoice Cancelled",
-        "link": "/AppDomain.Invoices.Contracts.IntegrationEvents.InvoiceCancelled",
-        "items": [],
-        "collapsed": false
-      },
-      {
-        "text": "Invoice Created",
-        "link": "/AppDomain.Invoices.Contracts.IntegrationEvents.InvoiceCreated",
-        "items": [],
-        "collapsed": false
-      },
-      {
         "text": "Invoice Created",
         "link": "/AppDomain.Invoices.Contracts.IntegrationEvents.InvoiceCreated",
         "items": [],
@@ -97,26 +67,8 @@
         "collapsed": false
       },
       {
-        "text": "Invoice Finalized",
-        "link": "/AppDomain.Invoices.Contracts.IntegrationEvents.InvoiceFinalized",
-        "items": [],
-        "collapsed": false
-      },
-      {
         "text": "Invoice Paid",
         "link": "/AppDomain.Invoices.Contracts.IntegrationEvents.InvoicePaid",
-        "items": [],
-        "collapsed": false
-      },
-      {
-        "text": "Invoice Paid",
-        "link": "/AppDomain.Invoices.Contracts.IntegrationEvents.InvoicePaid",
-        "items": [],
-        "collapsed": false
-      },
-      {
-        "text": "Payment Received",
-        "link": "/AppDomain.Invoices.Contracts.IntegrationEvents.PaymentReceived",
         "items": [],
         "collapsed": false
       },

--- a/libs/Momentum/src/Momentum.Extensions.Abstractions/Extensions/PluralizationExtensions.cs
+++ b/libs/Momentum/src/Momentum.Extensions.Abstractions/Extensions/PluralizationExtensions.cs
@@ -148,6 +148,13 @@ public static class PluralizationExtensions
         "volcano", "tornado", "mosquito", "domino", "mango"
     };
 
+    // Words ending in -ed that are genuine nouns, not past-tense/participle verb forms (e.g. "created",
+    // "processed") that shouldn't be pluralized at all — see ShouldPluralize.
+    private static readonly HashSet<string> EdEndingNouns = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "bed", "sled", "shed", "reed", "seed", "weed", "deed", "need", "feed", "speed", "breed", "creed", "greed"
+    };
+
     private static readonly HashSet<char> Vowels = ['a', 'e', 'i', 'o', 'u'];
 
     private static readonly HashSet<string> PluralIndicatingSuffixes = new(StringComparer.OrdinalIgnoreCase)
@@ -278,8 +285,21 @@ public static class PluralizationExtensions
         if (UncountableNouns.Contains(word))
             return false;
 
+        // Check if it looks like a past-tense verb/participle rather than a noun (e.g. "created",
+        // "order-completed") — pluralizing those produces nonsense like "createds". A trailing hyphenated
+        // segment still matches, since EndsWith only looks at the tail of the string.
+        if (LooksLikePastParticiple(word))
+            return false;
+
         return !IsPluralByRules(word);
     }
+
+    /// <summary>
+    ///     Heuristic: a word ending in "-ed" is treated as a past-tense verb/participle, not a pluralizable
+    ///     noun, unless it's one of the handful of genuine short "-ed" nouns (bed, seed, speed, ...).
+    /// </summary>
+    private static bool LooksLikePastParticiple(string word) =>
+        word.Length > 2 && word.EndsWith("ed", StringComparison.OrdinalIgnoreCase) && !EdEndingNouns.Contains(word);
 
     private static bool IsPluralByRules(string word)
     {

--- a/libs/Momentum/src/Momentum.Extensions.Abstractions/Messaging/EventTopicAttribute.cs
+++ b/libs/Momentum/src/Momentum.Extensions.Abstractions/Messaging/EventTopicAttribute.cs
@@ -60,12 +60,19 @@ public class EventTopicAttribute(string topic, string? domain = null, string? su
     /// </summary>
     public bool Internal { get; set; }
 
-
     /// <summary>
     ///     Gets a value indicating whether the topic name should be pluralized.
     ///     Returns <c>false</c> for explicitly named topics.
     /// </summary>
     public virtual bool ShouldPluralizeTopicName => false;
+
+    /// <summary>
+    ///     Whether the topic segment should be dropped from the fully-qualified topic name when it exactly
+    ///     matches the domain[.subdomain] path (e.g. domain <c>"orders"</c> with no subdomain and topic
+    ///     <c>"orders"</c> would otherwise produce <c>"orders.orders.v1"</c>). Defaults to <c>true</c>; set
+    ///     to <c>false</c> to always keep the topic segment even when it duplicates the domain path.
+    /// </summary>
+    public bool CollapseTopicOnDomain { get; set; } = true;
 }
 
 /// <summary>

--- a/libs/Momentum/src/Momentum.Extensions.EventMarkdownGenerator/Services/EventMetadataBuilder.cs
+++ b/libs/Momentum/src/Momentum.Extensions.EventMarkdownGenerator/Services/EventMetadataBuilder.cs
@@ -29,19 +29,27 @@ public static class EventMetadataBuilder
         // Access properties via reflection for cross-assembly compatibility
         var attrType = topicAttribute.GetType();
         var topic = TypeUtils.GetPropertyValue<string?>(attrType, topicAttribute, "Topic");
-        var shouldPluralize = TypeUtils.GetPropertyValue<bool?>(attrType, topicAttribute, "ShouldPluralizeTopicName") ?? false;
+        var shouldPluralize = TypeUtils.GetPropertyValue<bool?>(attrType, topicAttribute, "ShouldPluralizeTopicName") ?? true;
         var domain = TypeUtils.GetPropertyValue<string?>(attrType, topicAttribute, "Domain");
         var subdomain = TypeUtils.GetPropertyValue<string?>(attrType, topicAttribute, "Subdomain");
         var isInternal = TypeUtils.GetPropertyValue<bool?>(attrType, topicAttribute, "Internal") ?? false;
         var version = TypeUtils.GetPropertyValue<string?>(attrType, topicAttribute, "Version") ?? "v1";
         var eventNameOverride = TypeUtils.GetPropertyValue<string?>(attrType, topicAttribute, "EventName");
+        var eventName = !string.IsNullOrWhiteSpace(eventNameOverride) ? eventNameOverride : eventType.Name;
+        var eventNameKebab = eventName.ToKebabCase();
 
-        var topicName = !string.IsNullOrEmpty(topic) ? topic : eventType.Name.ToKebabCase();
+        var (entityName, entityType) = GetEntity(attrType, eventType, properties);
 
-        // shouldPluralize (ShouldPluralizeTopicName) is the topic-explicit signal: for EventTopicAttribute<T>
-        // it's true only when the attribute's own topic ctor argument was null, i.e. Topic was auto-derived
-        // from the entity type name rather than explicitly set (Topic itself is never empty by this point —
-        // the base ctor defaults it to the kebab-cased entity name even when not explicitly given).
+        // topicIsExplicit just picks which string is used: the attribute's own Topic when non-empty,
+        // otherwise the entity name.
+        //
+        // Pluralization is a separate concern, driven purely by the shouldPluralize flag read above from
+        // ShouldPluralizeTopicName, which defaults to true when an attribute doesn't declare it at all.
+        // It applies to whichever string got selected, explicit or not.
+        var topicIsExplicit = !string.IsNullOrEmpty(topic);
+
+        var topicName = topicIsExplicit ? topic! : entityName.ToKebabCase();
+
         if (shouldPluralize && !topicName.EndsWith("s", StringComparison.OrdinalIgnoreCase))
         {
             topicName = topicName.Pluralize();
@@ -63,24 +71,35 @@ public static class EventMetadataBuilder
         else if (emitPublicVisibility)
             visibilitySegment = "public";
 
+        var domainPath = string.Join('.',
+            new[] { eventDomain.ToKebabCase(), eventSubdomain?.ToKebabCase() }.Where(s => !string.IsNullOrEmpty(s)));
+
+        // An auto-derived topic (entity name, pluralized) can collide with the domain/subdomain path itself —
+        // e.g. domain "orders" with no subdomain and entity "Order" both kebab to "orders". In that case skip
+        // re-appending the topic segment rather than emitting a redundant "orders.orders". An explicit Topic
+        // is never collapsed this way, even if it happens to match the domain path.
+        //
+        // topicIsExplicit alone isn't enough here: EventTopicAttribute<T> always pre-fills Topic to the
+        // kebab-cased entity name even when its own topic ctor argument was omitted, so a non-empty Topic
+        // doesn't necessarily mean the caller chose it — shouldPluralize is what actually signals that.
+        var topicIsAutoDerived = !topicIsExplicit || shouldPluralize;
+        var topicDuplicatesDomainPath = topicIsAutoDerived && string.Equals(topicName, domainPath, StringComparison.OrdinalIgnoreCase);
+
         var segments = new List<string?>
         {
             visibilitySegment,
             eventDomain.ToKebabCase(),
             eventSubdomain?.ToKebabCase(),
-            topicName,
+            topicDuplicatesDomainPath ? null : topicName,
             version
         };
 
         var fullTopicName = string.Join('.', segments.Where(s => !string.IsNullOrEmpty(s)));
 
-        var eventName = !string.IsNullOrWhiteSpace(eventNameOverride) ? eventNameOverride : eventType.Name;
-        var (entityName, entityType) = GetEntity(attrType, eventType, properties);
-
         return new EventMetadata
         {
             EventName = eventName,
-            EventNameKebab = eventName.ToKebabCase(),
+            EventNameKebab = eventNameKebab,
             EventTypeName = eventType.Name,
             FullTypeName = eventType.FullName ?? eventType.Name,
             Namespace = eventType.Namespace ?? string.Empty,

--- a/libs/Momentum/src/Momentum.Extensions.EventMarkdownGenerator/Services/EventMetadataBuilder.cs
+++ b/libs/Momentum/src/Momentum.Extensions.EventMarkdownGenerator/Services/EventMetadataBuilder.cs
@@ -29,12 +29,17 @@ public static class EventMetadataBuilder
         // Access properties via reflection for cross-assembly compatibility
         var attrType = topicAttribute.GetType();
         var topic = TypeUtils.GetPropertyValue<string?>(attrType, topicAttribute, "Topic");
+
+        // Behavior flags shaping how the topic segment is derived/rendered, not raw metadata values.
         var shouldPluralize = TypeUtils.GetPropertyValue<bool?>(attrType, topicAttribute, "ShouldPluralizeTopicName") ?? true;
+        var collapseTopicOnDomain = TypeUtils.GetPropertyValue<bool?>(attrType, topicAttribute, "CollapseTopicOnDomain") ?? true;
+
         var domain = TypeUtils.GetPropertyValue<string?>(attrType, topicAttribute, "Domain");
         var subdomain = TypeUtils.GetPropertyValue<string?>(attrType, topicAttribute, "Subdomain");
         var isInternal = TypeUtils.GetPropertyValue<bool?>(attrType, topicAttribute, "Internal") ?? false;
         var version = TypeUtils.GetPropertyValue<string?>(attrType, topicAttribute, "Version") ?? "v1";
         var eventNameOverride = TypeUtils.GetPropertyValue<string?>(attrType, topicAttribute, "EventName");
+
         var eventName = !string.IsNullOrWhiteSpace(eventNameOverride) ? eventNameOverride : eventType.Name;
         var eventNameKebab = eventName.ToKebabCase();
 
@@ -42,12 +47,7 @@ public static class EventMetadataBuilder
 
         // topicIsExplicit just picks which string is used: the attribute's own Topic when non-empty,
         // otherwise the entity name.
-        //
-        // Pluralization is a separate concern, driven purely by the shouldPluralize flag read above from
-        // ShouldPluralizeTopicName, which defaults to true when an attribute doesn't declare it at all.
-        // It applies to whichever string got selected, explicit or not.
         var topicIsExplicit = !string.IsNullOrEmpty(topic);
-
         var topicName = topicIsExplicit ? topic! : entityName.ToKebabCase();
 
         if (shouldPluralize && !topicName.EndsWith("s", StringComparison.OrdinalIgnoreCase))
@@ -74,16 +74,11 @@ public static class EventMetadataBuilder
         var domainPath = string.Join('.',
             new[] { eventDomain.ToKebabCase(), eventSubdomain?.ToKebabCase() }.Where(s => !string.IsNullOrEmpty(s)));
 
-        // An auto-derived topic (entity name, pluralized) can collide with the domain/subdomain path itself —
-        // e.g. domain "orders" with no subdomain and entity "Order" both kebab to "orders". In that case skip
-        // re-appending the topic segment rather than emitting a redundant "orders.orders". An explicit Topic
-        // is never collapsed this way, even if it happens to match the domain path.
-        //
-        // topicIsExplicit alone isn't enough here: EventTopicAttribute<T> always pre-fills Topic to the
-        // kebab-cased entity name even when its own topic ctor argument was omitted, so a non-empty Topic
-        // doesn't necessarily mean the caller chose it — shouldPluralize is what actually signals that.
-        var topicIsAutoDerived = !topicIsExplicit || shouldPluralize;
-        var topicDuplicatesDomainPath = topicIsAutoDerived && string.Equals(topicName, domainPath, StringComparison.OrdinalIgnoreCase);
+        // A topic that exactly matches the domain[.subdomain] path would otherwise produce a redundant
+        // segment (e.g. domain "orders" + topic "orders" -> "orders.orders.v1"). CollapseTopicOnDomain
+        // (read above, default true) controls whether that segment is dropped; set it to false on the
+        // attribute to always keep both segments even when they duplicate each other.
+        var topicDuplicatesDomainPath = collapseTopicOnDomain && string.Equals(topicName, domainPath, StringComparison.OrdinalIgnoreCase);
 
         var segments = new List<string?>
         {

--- a/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/GenericAttributeDiscoveryTests.cs
+++ b/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/GenericAttributeDiscoveryTests.cs
@@ -24,6 +24,7 @@ public class GenericAttributeDiscoveryTests
         public bool Internal { get; init; }
         public string? Topic { get; init; }
         public string? EventName { get; init; }
+        public bool CollapseTopicOnDomain { get; init; } = true;
     }
 
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter)]
@@ -113,6 +114,51 @@ public class GenericAttributeDiscoveryTests
         orderApproved.Entity.ShouldBe("Order");
         orderApproved.Topic.ShouldBe("orders");
         orderApproved.FullyQualifiedTopicName.ShouldBe("orders.v1");
+    }
+
+    [ConventionEventTopic(Domain = "orders", Topic = "orders")]
+    public record OrderRefunded(Guid OrderId);
+
+    [Fact]
+    public void DiscoverEvents_WithExplicitTopicMatchingDomain_CollapsesByDefault()
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+
+        var events = AssemblyEventDiscovery.DiscoverEvents(
+            assembly,
+            xmlParser: null,
+            PayloadSizeCalculator.Create("json"),
+            attributeNamePrefix: nameof(ConventionEventTopicAttribute)).Select(e => e.Metadata).ToList();
+
+        var orderRefunded = events.Single(e => e.FullTypeName == typeof(OrderRefunded).FullName);
+
+        // CollapseTopicOnDomain defaults to true regardless of whether Topic was explicit or auto-derived
+        // from the entity — here it's explicit ("orders") and still collapses because it matches the
+        // domain path exactly.
+        orderRefunded.Topic.ShouldBe("orders");
+        orderRefunded.FullyQualifiedTopicName.ShouldBe("orders.v1");
+    }
+
+    [ConventionEventTopic(Domain = "orders", Topic = "orders", CollapseTopicOnDomain = false)]
+    public record OrderIssued(Guid OrderId);
+
+    [Fact]
+    public void DiscoverEvents_WithCollapseTopicOnDomainFalse_KeepsDuplicateSegment()
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+
+        var events = AssemblyEventDiscovery.DiscoverEvents(
+            assembly,
+            xmlParser: null,
+            PayloadSizeCalculator.Create("json"),
+            attributeNamePrefix: nameof(ConventionEventTopicAttribute)).Select(e => e.Metadata).ToList();
+
+        var orderIssued = events.Single(e => e.FullTypeName == typeof(OrderIssued).FullName);
+
+        // Explicitly opting out (CollapseTopicOnDomain = false) keeps both segments even though topic and
+        // domain are identical — the caller's choice always wins over the default.
+        orderIssued.Topic.ShouldBe("orders");
+        orderIssued.FullyQualifiedTopicName.ShouldBe("orders.orders.v1");
     }
 
     [ConventionEventTopic(Domain = "commerce", Subdomain = "orders")]

--- a/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/GenericAttributeDiscoveryTests.cs
+++ b/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/GenericAttributeDiscoveryTests.cs
@@ -19,6 +19,7 @@ public class GenericAttributeDiscoveryTests
     public sealed class ConventionEventTopicAttribute : Attribute
     {
         public string? Domain { get; init; }
+        public string? Subdomain { get; init; }
         public string Version { get; init; } = "v1";
         public bool Internal { get; init; }
         public string? Topic { get; init; }
@@ -67,8 +68,82 @@ public class GenericAttributeDiscoveryTests
         conventionEvent.PartitionKeys[1].Order.ShouldBe(1);
     }
 
+    [ConventionEventTopic(Domain = "sales")]
+    public record OrderCreated(Guid OrderId);
+
+    [Fact]
+    public void DiscoverEvents_WithNoTopic_DerivesTopicFromPluralizedEntityNotEventName()
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+
+        var events = AssemblyEventDiscovery.DiscoverEvents(
+            assembly,
+            xmlParser: null,
+            PayloadSizeCalculator.Create("json"),
+            attributeNamePrefix: nameof(ConventionEventTopicAttribute)).Select(e => e.Metadata).ToList();
+
+        var orderCreated = events.Single(e => e.FullTypeName == typeof(OrderCreated).FullName);
+
+        // No Topic set: the fallback derives from the pluralized, kebab-cased Entity ("Order" -> "orders"),
+        // not the event name ("OrderCreated" -> "order-created") and not the raw CLR type name.
+        orderCreated.Entity.ShouldBe("Order");
+        orderCreated.Topic.ShouldBe("orders");
+        orderCreated.FullyQualifiedTopicName.ShouldBe("sales.orders.v1");
+    }
+
+    [ConventionEventTopic(Domain = "orders")]
+    public record OrderApproved(Guid OrderId);
+
+    [Fact]
+    public void DiscoverEvents_WithNoTopicAndDomainMatchingEntity_CollapsesDuplicateSegment()
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+
+        var events = AssemblyEventDiscovery.DiscoverEvents(
+            assembly,
+            xmlParser: null,
+            PayloadSizeCalculator.Create("json"),
+            attributeNamePrefix: nameof(ConventionEventTopicAttribute)).Select(e => e.Metadata).ToList();
+
+        var orderApproved = events.Single(e => e.FullTypeName == typeof(OrderApproved).FullName);
+
+        // Domain "orders" (no subdomain) and the auto-derived topic ("Order" -> "orders") both kebab to
+        // the same string. Topic itself still reports "orders", but the fully-qualified name must not
+        // repeat the segment ("orders.v1", not "orders.orders.v1").
+        orderApproved.Entity.ShouldBe("Order");
+        orderApproved.Topic.ShouldBe("orders");
+        orderApproved.FullyQualifiedTopicName.ShouldBe("orders.v1");
+    }
+
+    [ConventionEventTopic(Domain = "commerce", Subdomain = "orders")]
+    public record OrderSubmitted(Guid OrderId);
+
+    [Fact]
+    public void DiscoverEvents_WithNoTopicAndSubdomainMatchingEntity_DoesNotCollapse()
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+
+        var events = AssemblyEventDiscovery.DiscoverEvents(
+            assembly,
+            xmlParser: null,
+            PayloadSizeCalculator.Create("json"),
+            attributeNamePrefix: nameof(ConventionEventTopicAttribute)).Select(e => e.Metadata).ToList();
+
+        var orderSubmitted = events.Single(e => e.FullTypeName == typeof(OrderSubmitted).FullName);
+
+        // The dedupe only collapses when the topic duplicates the FULL domain[.subdomain] path. Here the
+        // subdomain alone ("orders") matches the auto-derived topic, but the domain ("commerce") doesn't,
+        // so the full path "commerce.orders" != "orders" and the topic segment is NOT dropped — unlike
+        // DiscoverEvents_WithNoTopicAndDomainMatchingEntity_CollapsesDuplicateSegment, where domain alone
+        // (no subdomain) matches and the segment IS dropped.
+        orderSubmitted.Entity.ShouldBe("Order");
+        orderSubmitted.Topic.ShouldBe("orders");
+        orderSubmitted.Subdomain.ShouldBe("orders");
+        orderSubmitted.FullyQualifiedTopicName.ShouldBe("commerce.orders.orders.v1");
+    }
+
     // Custom attribute exercising a property the generator has no dedicated EventMetadata field for
-    // (Notes), plus an explicitly empty Topic to verify the kebab-case fallback still applies.
+    // (Notes), plus an explicitly empty Topic to verify the entity-fallback still applies.
     [AttributeUsage(AttributeTargets.Class)]
     public sealed class CustomAttribute : Attribute
     {
@@ -93,8 +168,10 @@ public class GenericAttributeDiscoveryTests
 
         var customEvent = events.Single(e => e.FullTypeName == typeof(CustomAttributeEvent).FullName);
 
-        // Empty Topic falls back to the kebab-cased CLR type name, same as a missing Topic would.
-        customEvent.Topic.ShouldBe("custom-attribute-event");
+        // Empty Topic falls back to the pluralized, kebab-cased Entity, same as a missing Topic would.
+        // CustomAttribute has no TEntity to reflect, so Entity is derived by stripping the trailing
+        // "Event" word from the CLR type name ("CustomAttributeEvent" -> "CustomAttribute" -> "custom-attributes").
+        customEvent.Topic.ShouldBe("custom-attributes");
 
         // Every property of the attribute is captured, including ones with no dedicated EventMetadata
         // field (Notes) — not just the well-known ones (Domain).

--- a/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/all-properties-showcase/expected/TestEvents.AppDomain.Comprehensive.Contracts.IntegrationEvents.AllPropertiesShowcaseEvent.md
+++ b/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/all-properties-showcase/expected/TestEvents.AppDomain.Comprehensive.Contracts.IntegrationEvents.AllPropertiesShowcaseEvent.md
@@ -40,7 +40,7 @@ renderable field of the generated markdown at once.
 - **TotalEstimatedSizeBytes:** 372
 - **HasInaccurateEstimates:** true
 
-## AttributeProperties (6)
+## AttributeProperties (7)
 
 - `ShouldPluralizeTopicName` = `False`
 - `Topic` = `comprehensive-topic`
@@ -48,6 +48,7 @@ renderable field of the generated markdown at once.
 - `Subdomain` = ``
 - `Version` = `v9`
 - `Internal` = `True`
+- `CollapseTopicOnDomain` = `True`
 
 
 ## Properties (4)

--- a/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/basic-event/expected/TestEvents.AppDomain.Collections.Contracts.IntegrationEvents.BulkDataProcessed.md
+++ b/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/basic-event/expected/TestEvents.AppDomain.Collections.Contracts.IntegrationEvents.BulkDataProcessed.md
@@ -11,8 +11,8 @@ editLink: false
 - **Version:** v1
 - **Entity:** `BulkDataProcessed`
 - **Type:** Integration Event
-- **Topic:** `bulk-data-processeds`
-- **Fully Qualified Topic:** `test-events.collections.bulk-data-processeds.v1`
+- **Topic:** `bulk-data-processed`
+- **Fully Qualified Topic:** `test-events.collections.bulk-data-processed.v1`
 - **Estimated Payload Size:** 399 bytes ⚠️ *Contains dynamic properties*
 - **Partition Keys**: TenantId
 

--- a/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/basic-event/expected/TestEvents.AppDomain.Legacy.Contracts.IntegrationEvents.PaymentProcessed.md
+++ b/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/basic-event/expected/TestEvents.AppDomain.Legacy.Contracts.IntegrationEvents.PaymentProcessed.md
@@ -14,8 +14,8 @@ editLink: false
 - **Version:** v1
 - **Entity:** `PaymentProcessed`
 - **Type:** Integration Event
-- **Topic:** `payment-processeds`
-- **Fully Qualified Topic:** `test-events.legacy.payment-processeds.v1`
+- **Topic:** `payment-processed`
+- **Fully Qualified Topic:** `test-events.legacy.payment-processed.v1`
 - **Estimated Payload Size:** 32 bytes ⚠️ *Contains dynamic properties*
 - **Partition Keys**: TenantId
 

--- a/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/basic-event/expected/TestEvents.AppDomain.Types.Contracts.IntegrationEvents.PaymentStatusChanged.md
+++ b/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/basic-event/expected/TestEvents.AppDomain.Types.Contracts.IntegrationEvents.PaymentStatusChanged.md
@@ -11,8 +11,8 @@ editLink: false
 - **Version:** v1
 - **Entity:** `PaymentStatusChanged`
 - **Type:** Integration Event
-- **Topic:** `payment-status-changeds`
-- **Fully Qualified Topic:** `test-events.types.payment-status-changeds.v1`
+- **Topic:** `payment-status-changed`
+- **Fully Qualified Topic:** `test-events.types.payment-status-changed.v1`
 - **Estimated Payload Size:** 56 bytes ⚠️ *Contains dynamic properties*
 - **Partition Keys**: TenantId
 

--- a/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/basic-event/expected/TestEvents.Enterprise.AppDomain.Payments.Gateway.External.Contracts.IntegrationEvents.ExternalPaymentGatewayResponseReceived.md
+++ b/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/basic-event/expected/TestEvents.Enterprise.AppDomain.Payments.Gateway.External.Contracts.IntegrationEvents.ExternalPaymentGatewayResponseReceived.md
@@ -11,8 +11,8 @@ editLink: false
 - **Version:** v1
 - **Entity:** `ExternalPaymentGatewayResponseReceived`
 - **Type:** Integration Event
-- **Topic:** `external-payment-gateway-response-receiveds`
-- **Fully Qualified Topic:** `test-events.external.external-payment-gateway-response-receiveds.v1`
+- **Topic:** `external-payment-gateway-response-received`
+- **Fully Qualified Topic:** `test-events.external.external-payment-gateway-response-received.v1`
 - **Estimated Payload Size:** 55 bytes ⚠️ *Contains dynamic properties*
 - **Partition Keys**: TenantId
 

--- a/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/basic-event/expected/TestEvents.Graph.Nodes.Contracts.IntegrationEvents.NodeRelationshipCreated.md
+++ b/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/basic-event/expected/TestEvents.Graph.Nodes.Contracts.IntegrationEvents.NodeRelationshipCreated.md
@@ -11,8 +11,8 @@ editLink: false
 - **Version:** v1
 - **Entity:** `NodeRelationshipCreated`
 - **Type:** Integration Event
-- **Topic:** `node-relationship-createds`
-- **Fully Qualified Topic:** `test-events.nodes.node-relationship-createds.v1`
+- **Topic:** `node-relationship-created`
+- **Fully Qualified Topic:** `test-events.nodes.node-relationship-created.v1`
 - **Estimated Payload Size:** 382 bytes ⚠️ *Contains dynamic properties*
 - **Partition Keys**: TenantId
 

--- a/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/basic-event/expected/TestEvents.Platform.AppDomain.Invoices.Contracts.IntegrationEvents.InvoiceGenerated.md
+++ b/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/basic-event/expected/TestEvents.Platform.AppDomain.Invoices.Contracts.IntegrationEvents.InvoiceGenerated.md
@@ -11,8 +11,8 @@ editLink: false
 - **Version:** v1
 - **Entity:** `InvoiceGenerated`
 - **Type:** Integration Event
-- **Topic:** `invoice-generateds`
-- **Fully Qualified Topic:** `test-events.invoices.invoice-generateds.v1`
+- **Topic:** `invoice-generated`
+- **Fully Qualified Topic:** `test-events.invoices.invoice-generated.v1`
 - **Estimated Payload Size:** 32 bytes ⚠️ *Contains dynamic properties*
 - **Partition Keys**: TenantId
 

--- a/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/basic-event/expected/TestEvents.Platform.AppDomain.Payments.Contracts.IntegrationEvents.PaymentProcessed.md
+++ b/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/basic-event/expected/TestEvents.Platform.AppDomain.Payments.Contracts.IntegrationEvents.PaymentProcessed.md
@@ -11,8 +11,8 @@ editLink: false
 - **Version:** v1
 - **Entity:** `PaymentProcessed`
 - **Type:** Integration Event
-- **Topic:** `payment-processeds`
-- **Fully Qualified Topic:** `test-events.payments.payment-processeds.v1`
+- **Topic:** `payment-processed`
+- **Fully Qualified Topic:** `test-events.payments.payment-processed.v1`
 - **Estimated Payload Size:** 32 bytes ⚠️ *Contains dynamic properties*
 - **Partition Keys**: TenantId
 

--- a/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/basic-event/expected/TestEvents.Platform.Subscriptions.Contracts.IntegrationEvents.SubscriptionActivated.md
+++ b/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/basic-event/expected/TestEvents.Platform.Subscriptions.Contracts.IntegrationEvents.SubscriptionActivated.md
@@ -11,8 +11,8 @@ editLink: false
 - **Version:** v1
 - **Entity:** `SubscriptionActivated`
 - **Type:** Integration Event
-- **Topic:** `subscription-activateds`
-- **Fully Qualified Topic:** `test-events.subscriptions.subscription-activateds.v1`
+- **Topic:** `subscription-activated`
+- **Fully Qualified Topic:** `test-events.subscriptions.subscription-activated.v1`
 - **Estimated Payload Size:** 16 bytes ⚠️ *Contains dynamic properties*
 - **Partition Keys**: TenantId
 

--- a/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/basic-event/expected/TestEvents.Platform.Subscriptions.Contracts.IntegrationEvents.SubscriptionCancelled.md
+++ b/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/basic-event/expected/TestEvents.Platform.Subscriptions.Contracts.IntegrationEvents.SubscriptionCancelled.md
@@ -11,8 +11,8 @@ editLink: false
 - **Version:** v1
 - **Entity:** `SubscriptionCancelled`
 - **Type:** Integration Event
-- **Topic:** `subscription-cancelleds`
-- **Fully Qualified Topic:** `test-events.subscriptions.subscription-cancelleds.v1`
+- **Topic:** `subscription-cancelled`
+- **Fully Qualified Topic:** `test-events.subscriptions.subscription-cancelled.v1`
 - **Estimated Payload Size:** 24 bytes ⚠️ *Contains dynamic properties*
 - **Partition Keys**: TenantId
 

--- a/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/basic-event/expected/TestEvents.Platform.Users.Contracts.IntegrationEvents.UserCreated.md
+++ b/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/basic-event/expected/TestEvents.Platform.Users.Contracts.IntegrationEvents.UserCreated.md
@@ -11,8 +11,8 @@ editLink: false
 - **Version:** v1
 - **Entity:** `UserCreated`
 - **Type:** Integration Event
-- **Topic:** `user-createds`
-- **Fully Qualified Topic:** `test-events.users.user-createds.v1`
+- **Topic:** `user-created`
+- **Fully Qualified Topic:** `test-events.users.user-created.v1`
 - **Estimated Payload Size:** 16 bytes ⚠️ *Contains dynamic properties*
 - **Partition Keys**: TenantId
 

--- a/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/basic-event/expected/TestEvents.Platform.Users.Contracts.IntegrationEvents.UserDeleted.md
+++ b/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/basic-event/expected/TestEvents.Platform.Users.Contracts.IntegrationEvents.UserDeleted.md
@@ -11,8 +11,8 @@ editLink: false
 - **Version:** v1
 - **Entity:** `UserDeleted`
 - **Type:** Integration Event
-- **Topic:** `user-deleteds`
-- **Fully Qualified Topic:** `test-events.users.user-deleteds.v1`
+- **Topic:** `user-deleted`
+- **Fully Qualified Topic:** `test-events.users.user-deleted.v1`
 - **Estimated Payload Size:** 24 bytes ⚠️ *Contains dynamic properties*
 - **Partition Keys**: TenantId
 

--- a/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/circular-references/expected/TestEvents.Graph.Nodes.Contracts.IntegrationEvents.NodeRelationshipCreated.md
+++ b/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/circular-references/expected/TestEvents.Graph.Nodes.Contracts.IntegrationEvents.NodeRelationshipCreated.md
@@ -11,8 +11,8 @@ editLink: false
 - **Version:** v1
 - **Entity:** `NodeRelationshipCreated`
 - **Type:** Integration Event
-- **Topic:** `node-relationship-createds`
-- **Fully Qualified Topic:** `test-events.nodes.node-relationship-createds.v1`
+- **Topic:** `node-relationship-created`
+- **Fully Qualified Topic:** `test-events.nodes.node-relationship-created.v1`
 - **Estimated Payload Size:** 382 bytes ⚠️ *Contains dynamic properties*
 - **Partition Keys**: TenantId
 

--- a/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/collection-types/expected/TestEvents.AppDomain.Collections.Contracts.IntegrationEvents.BulkDataProcessed.md
+++ b/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/collection-types/expected/TestEvents.AppDomain.Collections.Contracts.IntegrationEvents.BulkDataProcessed.md
@@ -11,8 +11,8 @@ editLink: false
 - **Version:** v1
 - **Entity:** `BulkDataProcessed`
 - **Type:** Integration Event
-- **Topic:** `bulk-data-processeds`
-- **Fully Qualified Topic:** `test-events.collections.bulk-data-processeds.v1`
+- **Topic:** `bulk-data-processed`
+- **Fully Qualified Topic:** `test-events.collections.bulk-data-processed.v1`
 - **Estimated Payload Size:** 399 bytes ⚠️ *Contains dynamic properties*
 - **Partition Keys**: TenantId
 

--- a/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/multiple-events-sidebar/expected/TestEvents.AppDomain.Legacy.Contracts.IntegrationEvents.PaymentProcessed.md
+++ b/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/multiple-events-sidebar/expected/TestEvents.AppDomain.Legacy.Contracts.IntegrationEvents.PaymentProcessed.md
@@ -14,8 +14,8 @@ editLink: false
 - **Version:** v1
 - **Entity:** `PaymentProcessed`
 - **Type:** Integration Event
-- **Topic:** `payment-processeds`
-- **Fully Qualified Topic:** `test-events.legacy.payment-processeds.v1`
+- **Topic:** `payment-processed`
+- **Fully Qualified Topic:** `test-events.legacy.payment-processed.v1`
 - **Estimated Payload Size:** 32 bytes ⚠️ *Contains dynamic properties*
 - **Partition Keys**: TenantId
 

--- a/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/multiple-events-sidebar/expected/TestEvents.Platform.AppDomain.Invoices.Contracts.IntegrationEvents.InvoiceGenerated.md
+++ b/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/multiple-events-sidebar/expected/TestEvents.Platform.AppDomain.Invoices.Contracts.IntegrationEvents.InvoiceGenerated.md
@@ -11,8 +11,8 @@ editLink: false
 - **Version:** v1
 - **Entity:** `InvoiceGenerated`
 - **Type:** Integration Event
-- **Topic:** `invoice-generateds`
-- **Fully Qualified Topic:** `test-events.invoices.invoice-generateds.v1`
+- **Topic:** `invoice-generated`
+- **Fully Qualified Topic:** `test-events.invoices.invoice-generated.v1`
 - **Estimated Payload Size:** 32 bytes ⚠️ *Contains dynamic properties*
 - **Partition Keys**: TenantId
 

--- a/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/multiple-events-sidebar/expected/TestEvents.Platform.AppDomain.Payments.Contracts.IntegrationEvents.PaymentProcessed.md
+++ b/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/multiple-events-sidebar/expected/TestEvents.Platform.AppDomain.Payments.Contracts.IntegrationEvents.PaymentProcessed.md
@@ -11,8 +11,8 @@ editLink: false
 - **Version:** v1
 - **Entity:** `PaymentProcessed`
 - **Type:** Integration Event
-- **Topic:** `payment-processeds`
-- **Fully Qualified Topic:** `test-events.payments.payment-processeds.v1`
+- **Topic:** `payment-processed`
+- **Fully Qualified Topic:** `test-events.payments.payment-processed.v1`
 - **Estimated Payload Size:** 32 bytes ⚠️ *Contains dynamic properties*
 - **Partition Keys**: TenantId
 

--- a/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/multiple-events-sidebar/expected/TestEvents.Platform.Subscriptions.Contracts.IntegrationEvents.SubscriptionActivated.md
+++ b/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/multiple-events-sidebar/expected/TestEvents.Platform.Subscriptions.Contracts.IntegrationEvents.SubscriptionActivated.md
@@ -11,8 +11,8 @@ editLink: false
 - **Version:** v1
 - **Entity:** `SubscriptionActivated`
 - **Type:** Integration Event
-- **Topic:** `subscription-activateds`
-- **Fully Qualified Topic:** `test-events.subscriptions.subscription-activateds.v1`
+- **Topic:** `subscription-activated`
+- **Fully Qualified Topic:** `test-events.subscriptions.subscription-activated.v1`
 - **Estimated Payload Size:** 16 bytes ⚠️ *Contains dynamic properties*
 - **Partition Keys**: TenantId
 

--- a/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/multiple-events-sidebar/expected/TestEvents.Platform.Users.Contracts.IntegrationEvents.UserCreated.md
+++ b/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/multiple-events-sidebar/expected/TestEvents.Platform.Users.Contracts.IntegrationEvents.UserCreated.md
@@ -11,8 +11,8 @@ editLink: false
 - **Version:** v1
 - **Entity:** `UserCreated`
 - **Type:** Integration Event
-- **Topic:** `user-createds`
-- **Fully Qualified Topic:** `test-events.users.user-createds.v1`
+- **Topic:** `user-created`
+- **Fully Qualified Topic:** `test-events.users.user-created.v1`
 - **Estimated Payload Size:** 16 bytes ⚠️ *Contains dynamic properties*
 - **Partition Keys**: TenantId
 

--- a/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/nested-namespaces/expected/TestEvents.Enterprise.AppDomain.Payments.Gateway.External.Contracts.IntegrationEvents.ExternalPaymentGatewayResponseReceived.md
+++ b/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/nested-namespaces/expected/TestEvents.Enterprise.AppDomain.Payments.Gateway.External.Contracts.IntegrationEvents.ExternalPaymentGatewayResponseReceived.md
@@ -11,8 +11,8 @@ editLink: false
 - **Version:** v1
 - **Entity:** `ExternalPaymentGatewayResponseReceived`
 - **Type:** Integration Event
-- **Topic:** `external-payment-gateway-response-receiveds`
-- **Fully Qualified Topic:** `test-events.external.external-payment-gateway-response-receiveds.v1`
+- **Topic:** `external-payment-gateway-response-received`
+- **Fully Qualified Topic:** `test-events.external.external-payment-gateway-response-received.v1`
 - **Estimated Payload Size:** 55 bytes ⚠️ *Contains dynamic properties*
 - **Partition Keys**: TenantId
 

--- a/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/nullable-and-enums/expected/TestEvents.AppDomain.Types.Contracts.IntegrationEvents.PaymentStatusChanged.md
+++ b/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/nullable-and-enums/expected/TestEvents.AppDomain.Types.Contracts.IntegrationEvents.PaymentStatusChanged.md
@@ -11,8 +11,8 @@ editLink: false
 - **Version:** v1
 - **Entity:** `PaymentStatusChanged`
 - **Type:** Integration Event
-- **Topic:** `payment-status-changeds`
-- **Fully Qualified Topic:** `test-events.types.payment-status-changeds.v1`
+- **Topic:** `payment-status-changed`
+- **Fully Qualified Topic:** `test-events.types.payment-status-changed.v1`
 - **Estimated Payload Size:** 56 bytes ⚠️ *Contains dynamic properties*
 - **Partition Keys**: TenantId
 

--- a/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/obsolete-event/expected/TestEvents.AppDomain.Legacy.Contracts.IntegrationEvents.PaymentProcessed.md
+++ b/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/obsolete-event/expected/TestEvents.AppDomain.Legacy.Contracts.IntegrationEvents.PaymentProcessed.md
@@ -14,8 +14,8 @@ editLink: false
 - **Version:** v1
 - **Entity:** `PaymentProcessed`
 - **Type:** Integration Event
-- **Topic:** `payment-processeds`
-- **Fully Qualified Topic:** `test-events.legacy.payment-processeds.v1`
+- **Topic:** `payment-processed`
+- **Fully Qualified Topic:** `test-events.legacy.payment-processed.v1`
 - **Estimated Payload Size:** 32 bytes ⚠️ *Contains dynamic properties*
 - **Partition Keys**: TenantId
 

--- a/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/obsolete-event/expected/TestEvents.Platform.AppDomain.Payments.Contracts.IntegrationEvents.PaymentProcessed.md
+++ b/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTestScenarios/obsolete-event/expected/TestEvents.Platform.AppDomain.Payments.Contracts.IntegrationEvents.PaymentProcessed.md
@@ -11,8 +11,8 @@ editLink: false
 - **Version:** v1
 - **Entity:** `PaymentProcessed`
 - **Type:** Integration Event
-- **Topic:** `payment-processeds`
-- **Fully Qualified Topic:** `test-events.payments.payment-processeds.v1`
+- **Topic:** `payment-processed`
+- **Fully Qualified Topic:** `test-events.payments.payment-processed.v1`
 - **Estimated Payload Size:** 32 bytes ⚠️ *Contains dynamic properties*
 - **Partition Keys**: TenantId
 

--- a/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/RealAttributeDomainCollisionTests.cs
+++ b/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/RealAttributeDomainCollisionTests.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Momentum .NET. All rights reserved.
+
+using Momentum.Extensions.Abstractions.Messaging;
+using Momentum.Extensions.EventMarkdownGenerator.Services;
+using Shouldly;
+using System.Reflection;
+using Xunit;
+
+namespace Momentum.Extensions.EventMarkdownGenerator.Tests;
+
+/// <summary>
+///     Same domain/topic dedupe scenario as GenericAttributeDiscoveryTests' Order* cases, but through the
+///     real, compiled <see cref="EventTopicAttribute{TEntity}"/> — not the test-local mock convention
+///     attribute — to prove the collapse also fires for actual template consumers.
+///
+///     These fixtures live in THIS test project (not TestEvents) deliberately: TestEvents is scanned
+///     wholesale by several other tests (sidebar generation, reference-format comparisons) that assert
+///     exact event/domain counts, so adding a real [EventTopic&lt;T&gt;] fixture there — especially one with
+///     its own distinct "orders" domain — would silently inflate those counts. Discovery here is filtered
+///     to this one type, so it can't affect them.
+/// </summary>
+public class RealAttributeDomainCollisionTests
+{
+    /// <summary>Minimal entity backing the real-attribute domain-collision fixture below.</summary>
+    public record Order
+    {
+        public required Guid Id { get; init; }
+    }
+
+    // No explicit topic: EventTopicAttribute<Order> auto-derives "orders" from the entity name. Domain is
+    // explicitly "orders" too, with no subdomain, so domain and auto-derived topic collide.
+    [EventTopic<Order>(domain: "orders")]
+    public sealed record OrderPlaced([PartitionKey] Guid OrderId);
+
+    [Fact]
+    public void DiscoverEvents_RealEventTopicAttributeWithDomainMatchingEntity_CollapsesDuplicateSegment()
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+
+        var events = AssemblyEventDiscovery.DiscoverEvents(
+            assembly,
+            xmlParser: null,
+            PayloadSizeCalculator.Create("json")).Select(e => e.Metadata).ToList();
+
+        var orderPlaced = events.Single(e => e.FullTypeName == typeof(OrderPlaced).FullName);
+
+        orderPlaced.Entity.ShouldBe("Order");
+        orderPlaced.Topic.ShouldBe("orders");
+        orderPlaced.Domain.ShouldBe("orders");
+        orderPlaced.Subdomain.ShouldBeNull();
+
+        // Without the dedupe this would be "orders.orders.v1".
+        orderPlaced.FullyQualifiedTopicName.ShouldBe("orders.v1");
+    }
+}

--- a/libs/Momentum/tests/Momentum.Extensions.Tests/Extensions/PluralizationServiceTests.cs
+++ b/libs/Momentum/tests/Momentum.Extensions.Tests/Extensions/PluralizationServiceTests.cs
@@ -128,6 +128,17 @@ public class PluralizationServiceTests
     [InlineData("Business", "Businesses")]
     [InlineData("Businesses", "Businesses")]
     [InlineData("Human", "Humans")]
+    // Past-tense verbs/participles - left unchanged, not pluralized
+    [InlineData("created", "created")]
+    [InlineData("updated", "updated")]
+    [InlineData("processed", "processed")]
+    [InlineData("reservation-created", "reservation-created")]
+    [InlineData("order-completed", "order-completed")]
+    // Genuine short "-ed" nouns - still pluralized normally
+    [InlineData("bed", "beds")]
+    [InlineData("shed", "sheds")]
+    [InlineData("seed", "seeds")]
+    [InlineData("speed", "speeds")]
     public void ToPlural_AllCases_ReturnsCorrectPlural(string value, string expectedPlural)
     {
         // Arrange & Act


### PR DESCRIPTION
## Summary
- `Pluralize()` no longer mangles past-tense/participle words (`"reservation-created"` → `"reservation-createds"`) — words ending in `-ed` are left unchanged, except a small allowlist of genuine `-ed` nouns (`bed`, `seed`, `speed`, ...).
- Topic fallback (no explicit `Topic`) now derives from the pluralized entity name instead of the event name.
- New `EventTopicAttribute.CollapseTopicOnDomain` property (default `true`): drops the topic segment from the fully-qualified topic name when it exactly duplicates the domain[.subdomain] path (e.g. domain `"orders"` + topic `"orders"` → `"orders.v1"` instead of `"orders.orders.v1"`); set `false` to always keep both segments.
- 22 scenario baselines regenerated to drop the same bad pluralization they'd baked in; `docs/events/events-sidebar.json` duplicate entries removed as a byproduct of a clean regeneration against the real `AppDomain`/`AppDomain.BackOffice` assemblies (confirmed zero diff in real event `.md` content — no real entity name collides with its domain or ends in `-ed`).

## Test plan
- [x] `dotnet test libs/Momentum/Momentum.slnx` — 629/629 pass
- [x] `dotnet test AppDomain.slnx` — unit suites pass (E2E requires live infra, not run)
- [x] New tests: `GenericAttributeDiscoveryTests` (fallback pluralization, domain/subdomain dedupe, explicit-topic-vs-domain collapse default and opt-out), `RealAttributeDomainCollisionTests` (same dedupe scenario via the real `EventTopicAttribute<T>`, isolated from `TestEvents` to avoid inflating its wholesale-scan test counts), `PluralizationServiceTests` (participle/noun-exception cases)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Qsu6wTTcdeYpjSnkGu3nqS