### PR TITLE
Fix conditional-marker style mismatch in event docs and README templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **EventMarkdownGenerator**: 22 event-doc scenario baselines regenerated to drop the bad pluralization they
   had baked in (`payment-processeds` → `payment-processed`, etc); `docs/events/events-sidebar.json`
   duplicate entries removed as a byproduct of regeneration.
+- **Template docs**: `docs/events/domain_events.md` and `integration_events.md` used HTML-comment-style
+  `<!--#if (INCLUDE_SAMPLE) -->` conditional markers, but `.template.config/template.json` configures `.md`
+  conditional processing for shell-style `# #if` / `# #endif` syntax (matching the rest of the repo's docs,
+  e.g. `docs/index.md`). The mismatch meant the directives were never recognized, so every default-generated
+  project shipped these two overview pages with the raw markers leaking into the rendered output. Both files
+  now use the `# #if` style already used elsewhere.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   e.g. `docs/index.md`). The mismatch meant the directives were never recognized, so every default-generated
   project shipped these two overview pages with the raw markers leaking into the rendered output. Both files
   now use the `# #if` style already used elsewhere.
+- **Template README**: same `<!--#if -->` vs `# #if` mismatch as above also broke `ProjectREADME.md` (the
+  generated project's root `README.md`) and `src/AppDomain.Contracts/README.md` — every generated project's
+  README shipped with ~100 raw conditional-marker lines instead of the intended content. Converted both to
+  `# #if` style; verified default, `--no-sample`, and `--orleans` generations all render correctly with no
+  leftover markers.
 
 ### Added
 

--- a/ProjectREADME.md
+++ b/ProjectREADME.md
@@ -14,40 +14,40 @@ The AppDomain solution demonstrates modern enterprise architecture patterns incl
 -   **CQRS pattern** with separate command and query handling
 -   **Pragmatic application-service style** over heavy domain object ceremony
 -   **Microservices architecture** with proper service boundaries
-<!--#if (INCLUDE_ORLEANS) -->
+# #if (INCLUDE_ORLEANS)
 -   **Orleans-based stateful processing** for complex business workflows
-<!--#endif -->
+# #endif
 -   **Comprehensive testing strategy** with unit and integration tests
 
-<!--#if (INCLUDE_SAMPLE) -->
+# #if (INCLUDE_SAMPLE)
 
 ### Key Business Domains
 
 -   **Cashiers**: Management of cashier entities and their payment capabilities
 -   **Invoices**: Invoice lifecycle management with state transitions and payment processing
-<!--#endif -->
+# #endif
 
 ## Architecture
 
 ```mermaid
 graph TB
     Client[Client Applications]
-    <!--#if (INCLUDE_API) -->
+    # #if (INCLUDE_API)
     subgraph "Front Office (Synchronous)"
         API[AppDomain.Api<br/>REST & gRPC]
     end
-    <!--#endif -->
+    # #endif
 
-    <!--#if (INCLUDE_BACK_OFFICE || INCLUDE_ORLEANS) -->
+    # #if (INCLUDE_BACK_OFFICE || INCLUDE_ORLEANS)
     subgraph "Back Office (Asynchronous)"
-        <!--#if (INCLUDE_BACK_OFFICE) -->
+        # #if (INCLUDE_BACK_OFFICE)
         BackOffice[AppDomain.BackOffice<br/>Event Processing]
-        <!--#endif -->
-        <!--#if (INCLUDE_ORLEANS) -->
+        # #endif
+        # #if (INCLUDE_ORLEANS)
         Orleans[AppDomain.BackOffice.Orleans<br/>Stateful Processing]
-        <!--#endif -->
+        # #endif
     end
-    <!--#endif -->
+    # #endif
 
     subgraph "Core Domain"
         Domain[AppDomain<br/>Commands, Queries, Events]
@@ -55,71 +55,71 @@ graph TB
     end
 
     subgraph "Infrastructure"
-        <!--#if (USE_DB) -->
+        # #if (USE_DB)
         DB[(PostgreSQL<br/>Primary Database)]
-        <!--#endif -->
-        <!--#if (USE_KAFKA) -->
+        # #endif
+        # #if (USE_KAFKA)
         Kafka[Apache Kafka<br/>Event Streaming]
-        <!--#endif -->
-        <!--#if (INCLUDE_ASPIRE) -->
+        # #endif
+        # #if (INCLUDE_ASPIRE)
         Aspire[.NET Aspire<br/>Orchestration]
-        <!--#endif -->
+        # #endif
     end
 
-    <!--#if (INCLUDE_API) -->
+    # #if (INCLUDE_API)
     Client -/-> API
     API -/-> Domain
-    <!--#endif -->
-    <!--#if (INCLUDE_BACK_OFFICE) -->
+    # #endif
+    # #if (INCLUDE_BACK_OFFICE)
     BackOffice -/-> Domain
-    <!--#endif -->
-    <!--#if (INCLUDE_ORLEANS) -->
+    # #endif
+    # #if (INCLUDE_ORLEANS)
     Orleans -/-> Domain
-    <!--#endif -->
+    # #endif
     Domain -/-> Contracts
-    <!--#if (INCLUDE_API && USE_DB) -->
+    # #if (INCLUDE_API && USE_DB)
     API -/-> DB
-    <!--#endif -->
-    <!--#if (INCLUDE_BACK_OFFICE && USE_DB) -->
+    # #endif
+    # #if (INCLUDE_BACK_OFFICE && USE_DB)
     BackOffice -/-> DB
-    <!--#endif -->
-    <!--#if (INCLUDE_ORLEANS && USE_DB) -->
+    # #endif
+    # #if (INCLUDE_ORLEANS && USE_DB)
     Orleans -/-> DB
-    <!--#endif -->
-    <!--#if (INCLUDE_BACK_OFFICE && USE_KAFKA) -->
+    # #endif
+    # #if (INCLUDE_BACK_OFFICE && USE_KAFKA)
     BackOffice -/-> Kafka
-    <!--#endif -->
-    <!--#if (INCLUDE_ORLEANS && USE_KAFKA) -->
+    # #endif
+    # #if (INCLUDE_ORLEANS && USE_KAFKA)
     Orleans -/-> Kafka
-    <!--#endif -->
-    <!--#if (INCLUDE_API && USE_KAFKA) -->
+    # #endif
+    # #if (INCLUDE_API && USE_KAFKA)
     API -/-> Kafka
-    <!--#endif -->
+    # #endif
 ```
 
 ## Project Structure
 
 <!-- prettier-ignore-start -->
-<!--#if (INCLUDE_API) -->
+# #if (INCLUDE_API)
 - **AppDomain.Api**: REST and gRPC endpoints for synchronous operations
-<!--#endif -->
-<!--#if (INCLUDE_BACK_OFFICE) -->
+# #endif
+# #if (INCLUDE_BACK_OFFICE)
 - **AppDomain.BackOffice**: Background event processing and integration workflows
-<!--#endif -->
-<!--#if (INCLUDE_ORLEANS) -->
+# #endif
+# #if (INCLUDE_ORLEANS)
 - **AppDomain.BackOffice.Orleans**: Stateful processing using Microsoft Orleans
-<!--#endif -->
-<!--#if (INCLUDE_ASPIRE) -->
+# #endif
+# #if (INCLUDE_ASPIRE)
 - **AppDomain.AppHost**: .NET Aspire orchestration for local development
-<!--#endif -->
+# #endif
 - **AppDomain**: Core domain logic with commands, queries, and events
 - **AppDomain.Contracts**: Shared contracts and integration events
-<!--#if (db == "liquibase") -->
+# #if (db == "liquibase")
 - **infra/AppDomain.Database**: Liquibase database migrations
-<!--#endif -->
-<!--#if (INCLUDE_DOCS) -->
+# #endif
+# #if (INCLUDE_DOCS)
 - **docs**: VitePress documentation site with auto-generated event docs
-<!--#endif -->
+# #endif
 <!-- prettier-ignore-end -->
 
 ## Port Allocations
@@ -129,29 +129,29 @@ The solution uses the following port allocations (default base port: 8100):
 <!-- prettier-ignore-start -->
 | Service | HTTP Port | HTTPS Port | Description |
 |---------|-----------|------------|-------------|
-<!--#if (INCLUDE_API) -->
+# #if (INCLUDE_API)
 | API (HTTP) | 8101 | 8111 | REST API endpoints |
 | API (gRPC) | 8102 | - | gRPC service endpoints |
-<!--#endif -->
-<!--#if (INCLUDE_BACK_OFFICE) -->
+# #endif
+# #if (INCLUDE_BACK_OFFICE)
 | BackOffice | 8103 | 8113 | Background processing service |
-<!--#endif -->
-<!--#if (INCLUDE_ORLEANS) -->
+# #endif
+# #if (INCLUDE_ORLEANS)
 | Orleans | 8104 | 8114 | Orleans silo endpoints |
-<!--#endif -->
-<!--#if (INCLUDE_ASPIRE) -->
+# #endif
+# #if (INCLUDE_ASPIRE)
 | Aspire Dashboard | 18100 | 18110 | .NET Aspire dashboard |
-<!--#endif -->
-<!--#if (INCLUDE_DOCS) -->
+# #endif
+# #if (INCLUDE_DOCS)
 | Documentation | 8119 | - | VitePress documentation site |
-<!--#endif -->
-<!--#if (USE_DB) -->
+# #endif
+# #if (USE_DB)
 | PostgreSQL | 54320 | - | Database server |
 | pgAdmin | 54321 | - | Database management UI |
-<!--#endif -->
-<!--#if (USE_KAFKA) -->
+# #endif
+# #if (USE_KAFKA)
 | Kafka | 59092 | - | Kafka broker |
-<!--#endif -->
+# #endif
 <!-- prettier-ignore-end -->
 
 ## Prerequisites
@@ -160,29 +160,29 @@ The solution uses the following port allocations (default base port: 8100):
 
 -   **.NET 10 SDK** or later
 -   **Container Solution (Docker, Rancher, Podman, etc)** - Required for databases, Kafka, etc
-<!--#if (USE_PGSQL) -->
+# #if (USE_PGSQL)
 -   **PostgreSQL** (handled by Docker Compose)
-    <!--#endif -->
-    <!--#if (USE_KAFKA) -->
+    # #endif
+    # #if (USE_KAFKA)
 -   **Apache Kafka** (handled by Docker Compose)
-<!--#endif -->
+# #endif
 -   **Git** for version control
 <!-- prettier-ignore-end -->
 
 ### Optional Tools
 
 <!-- prettier-ignore-start -->
-<!--#if (USE_PGSQL) -->
+# #if (USE_PGSQL)
 
 -   **pgAdmin** (included in Docker setup)
-<!--#endif -->
+# #endif
 -   **Visual Studio 2022** or **JetBrains Rider**
 -   **Postman** or similar for API testing
 <!-- prettier-ignore-end -->
 
 ## Getting Started
 
-<!--#if (INCLUDE_ASPIRE) -->
+# #if (INCLUDE_ASPIRE)
 
 ### Option 1: Using .NET Aspire (Recommended)
 
@@ -203,30 +203,30 @@ This will:
 -   Launch the Aspire dashboard at https://localhost:18110
 -   Set up service discovery and health monitoring
 -   Configure distributed tracing with OpenTelemetry
-<!--#endif -->
+# #endif
 
 ### Option 2: Using Docker Compose
 
 Run specific service profiles:
 
 ```bash
-<!--#if (INCLUDE_API) -->
+# #if (INCLUDE_API)
 # Run API services
 docker compose --profile api up
-<!--#endif -->
-<!--#if (INCLUDE_BACK_OFFICE) -->
+# #endif
+# #if (INCLUDE_BACK_OFFICE)
 # Run BackOffice services
 docker compose --profile backoffice up
-<!--#endif -->
-<!--#if (INCLUDE_ORLEANS) -->
+# #endif
+# #if (INCLUDE_ORLEANS)
 # Run Orleans services
 docker compose --profile orleans up
-<!--#endif -->
+# #endif
 # Run all services
 docker compose up
 ```
 
-<!--#if (db == "liquibase") -->
+# #if (db == "liquibase")
 
 ### Database Setup
 
@@ -245,7 +245,7 @@ docker compose up AppDomain-db AppDomain-db-migrations
 
 -   **Connection String**: `Host=localhost;Port=54320;Database=app_domain;Username=postgres;Password=password@`
 -   **pgAdmin**: http://localhost:54321 (admin@example.com / admin)
-<!--#endif -->
+# #endif
 
 ## Development Workflow
 
@@ -279,16 +279,16 @@ dotnet test tests/AppDomain.Tests
 1. **Define the Command/Query** in `src/AppDomain/[Domain]/Commands/` or `Queries/`
 2. **Implement the Handler** using Wolverine's handler pattern
 3. **Create Integration Events** in `src/AppDomain.Contracts/IntegrationEvents/`
- <!--#if (INCLUDE_API) -->
+ # #if (INCLUDE_API)
 4. **Add API Endpoints** in `src/AppDomain.Api/[Domain]/Controller.cs`
-    <!--#endif -->
-    <!--#if (db == "liquibase") -->
+    # #endif
+    # #if (db == "liquibase")
 5. **Create Database Migrations** in `infra/AppDomain.Database/Liquibase/`
- <!--#endif -->
+ # #endif
 6. **Write Tests** in `tests/AppDomain.Tests/`
  <!-- prettier-ignore-end -->
 
-<!--#if (INCLUDE_API) -->
+# #if (INCLUDE_API)
 
 ## API Documentation
 
@@ -300,7 +300,7 @@ dotnet test tests/AppDomain.Tests
 
 ### API Endpoints
 
-<!--#if (INCLUDE_SAMPLE) -->
+# #if (INCLUDE_SAMPLE)
 
 #### Cashiers API
 
@@ -321,10 +321,10 @@ dotnet test tests/AppDomain.Tests
 | POST   | `/api/invoices`          | Create new invoice   |
 | POST   | `/api/invoices/{id}/pay` | Mark invoice as paid |
 
-<!--#endif -->
-<!--#endif -->
+# #endif
+# #endif
 
-<!--#if (USE_KAFKA) -->
+# #if (USE_KAFKA)
 
 ## Event-Driven Architecture
 
@@ -332,7 +332,7 @@ dotnet test tests/AppDomain.Tests
 
 The solution uses Apache Kafka for event streaming:
 
-<!--#if (INCLUDE_SAMPLE) -->
+# #if (INCLUDE_SAMPLE)
 
 | Event           | Producer   | Consumers           | Description                 |
 | --------------- | ---------- | ------------------- | --------------------------- |
@@ -342,7 +342,7 @@ The solution uses Apache Kafka for event streaming:
 | InvoicePaid     | API        | BackOffice, Orleans | Payment received            |
 | PaymentReceived | BackOffice | Orleans             | Payment processing complete |
 
-<!--#endif -->
+# #endif
 
 ### Kafka Topics
 
@@ -350,7 +350,7 @@ Topics follow the naming convention: `app_domain.[domain].[event-type]`
 
 Example: `app_domain.cashiers.created`, `app_domain.invoices.paid`
 
-<!--#endif -->
+# #endif
 
 ## Configuration
 
@@ -359,17 +359,17 @@ Example: `app_domain.cashiers.created`, `app_domain.invoices.paid`
 | Variable               | Default     | Description         |
 | ---------------------- | ----------- | ------------------- |
 | ASPNETCORE_ENVIRONMENT | Development | Runtime environment |
-<!--#if (USE_DB) -->
+# #if (USE_DB)
 | ConnectionStrings\_\_AppDomainDb | - | PostgreSQL connection string |
 | ConnectionStrings\_\_ServiceBus | - | Service bus database connection |
-<!--#endif -->
-<!--#if (USE_KAFKA) -->
+# #endif
+# #if (USE_KAFKA)
 | ConnectionStrings\_\_Messaging | localhost:59092 | Kafka broker addresses |
-<!--#endif -->
-<!--#if (INCLUDE_ORLEANS) -->
+# #endif
+# #if (INCLUDE_ORLEANS)
 | Orleans\_\_ClusterId | dev | Orleans cluster identifier |
 | Orleans\_\_ServiceId | AppDomain | Orleans service identifier |
-<!--#endif -->
+# #endif
 
 ### Application Settings
 
@@ -400,18 +400,18 @@ Configuration is applied in this order (later sources override earlier ones):
 ### Docker Build
 
 ```bash
-<!--#if (INCLUDE_API) -->
+# #if (INCLUDE_API)
 # Build API image
 docker build -f src/AppDomain.Api/Dockerfile -t appdomain-api .
-<!--#endif -->
-<!--#if (INCLUDE_BACK_OFFICE) -->
+# #endif
+# #if (INCLUDE_BACK_OFFICE)
 # Build BackOffice image
 docker build -f src/AppDomain.BackOffice/Dockerfile -t appdomain-backoffice .
-<!--#endif -->
-<!--#if (INCLUDE_ORLEANS) -->
+# #endif
+# #if (INCLUDE_ORLEANS)
 # Build Orleans image
 docker build -f src/AppDomain.BackOffice.Orleans/Dockerfile -t appdomain-orleans .
-<!--#endif -->
+# #endif
 ```
 
 ### Production Considerations
@@ -438,15 +438,15 @@ OpenTelemetry metrics are exposed at `/metrics` (Prometheus format)
 
 ### Distributed Tracing
 
-<!--#if (INCLUDE_ASPIRE) -->
+# #if (INCLUDE_ASPIRE)
 
 Traces are collected by the Aspire dashboard and can be exported to:
 
-<!--#else -->
+# #else
 
 Traces can be exported to:
 
-<!--#endif -->
+# #endif
 
 -   Jaeger
 -   Zipkin
@@ -466,7 +466,7 @@ docker ps | grep postgres
 psql -h localhost -p 54320 -U postgres -d app_domain
 ```
 
-<!--#if (USE_KAFKA) -->
+# #if (USE_KAFKA)
 
 #### Kafka Connection Issues
 
@@ -478,9 +478,9 @@ docker ps | grep kafka
 docker exec -it <kafka-container> kafka-topics.sh --list --bootstrap-server localhost:9092
 ```
 
-<!--#endif -->
+# #endif
 
-<!--#if (INCLUDE_API) -->
+# #if (INCLUDE_API)
 
 #### API Not Responding
 
@@ -492,7 +492,7 @@ docker logs appdomain-api
 netstat -an | grep 8101
 ```
 
-<!--#endif -->
+# #endif
 
 #### Build Failures
 

--- a/docs/events/domain_events.md
+++ b/docs/events/domain_events.md
@@ -4,8 +4,8 @@
 
 | Event Name                                 | Description                                                                 | Status |
 | ------------------------------------------ | --------------------------------------------------------------------------- | ------ |
-<!--#if (INCLUDE_SAMPLE) -->
+# #if (INCLUDE_SAMPLE)
 | InvoiceGenerated | Internal event triggered when an invoice is generated for domain processing | Active |
-<!--#endif -->
+# #endif
 
 <!-- prettier-ignore-end -->

--- a/docs/events/integration_events.md
+++ b/docs/events/integration_events.md
@@ -4,7 +4,7 @@
 
 | Event Name                                 | Description                                                               | Status |
 | ------------------------------------------ | ------------------------------------------------------------------------- | ------ |
-<!--#if (INCLUDE_SAMPLE) -->
+# #if (INCLUDE_SAMPLE)
 | [InvoiceCreated](./integration_events/AppDomain.Invoices.Contracts.IntegrationEvents.InvoiceCreated.md)     | Published when a new invoice is created in the system                     | Active |
 | [InvoiceCancelled](./integration_events/AppDomain.Invoices.Contracts.IntegrationEvents.InvoiceCancelled.md) | Published when an invoice is cancelled                                    | Active |
 | [InvoiceFinalized](./integration_events/AppDomain.Invoices.Contracts.IntegrationEvents.InvoiceFinalized.md) | Published when an invoice is finalized during business day end processing | Active |
@@ -18,6 +18,6 @@
 | [CashierCreated](./integration_events/AppDomain.Cashiers.Contracts.IntegrationEvents.CashierCreated.md) | Published when a new cashier is created             | Active |
 | [CashierUpdated](./integration_events/AppDomain.Cashiers.Contracts.IntegrationEvents.CashierUpdated.md) | Published when an existing cashier is updated       | Active |
 | [CashierDeleted](./integration_events/AppDomain.Cashiers.Contracts.IntegrationEvents.CashierDeleted.md) | Published when a cashier is deleted from the system | Active |
-<!--#endif -->
+# #endif
 
 <!-- prettier-ignore-end -->

--- a/src/AppDomain.Contracts/README.md
+++ b/src/AppDomain.Contracts/README.md
@@ -11,18 +11,18 @@ Contracts (models, integration events, and optional gRPC protobufs) that define 
 <!-- prettier-ignore-start -->
 
 -   Domain Models
-    <!--#if (INCLUDE_SAMPLE) -->
+    # #if (INCLUDE_SAMPLE)
     -   Cashiers: `Cashier`, `CashierPayment`, …
     -   Invoices: domain-facing DTOs where applicable
-    <!--#endif -->
+    # #endif
 -   Integration Events
-    <!--#if (INCLUDE_SAMPLE) -->
+    # #if (INCLUDE_SAMPLE)
     -   Cashiers: `CashierCreated`, `CashierUpdated`, `CashierDeleted`
     -   Invoices: e.g. `InvoiceCancelled`
-    <!--#endif -->
-    <!--#if (INCLUDE_API) -->
+    # #endif
+    # #if (INCLUDE_API)
 -   gRPC Protobuf contracts (if AppDomain.Api is included at build time) - Shipped under the package path `Protos/` (e.g. `Invoices/Protos/...`)
-    <!--#endif -->
+    # #endif
 
 <!-- prettier-ignore-end -->
 
@@ -51,7 +51,7 @@ Note: In Debug builds the package may be published as a prerelease (suffix `-pre
 
 Implement a handler that consumes events from this package. Handlers generally follow the pattern Task Handle(TEvent) and can use constructor injection for dependencies like ILogger or IMessageBus.
 
-<!--#if (INCLUDE_SAMPLE) -->
+# #if (INCLUDE_SAMPLE)
 
 ```csharp
 using AppDomain.Cashiers.Contracts.IntegrationEvents;
@@ -79,7 +79,7 @@ Notes:
 -   Handler discovery and wiring depend on your messaging/bus setup. Many frameworks will auto-discover classes with a Handle(TEvent) method when registered in DI.
 -   Events use attributes from Momentum.Extensions.Abstractions.Messaging (e.g., EventTopic<T>, PartitionKey) that your transport can leverage for routing.
 
-<!--#else -->
+# #else
 
 ```csharp
 using AppDomain.Foo.Contracts.IntegrationEvents;
@@ -102,9 +102,9 @@ public class FooCreatedHandler(ILogger<FooCreatedHandler> logger)
 }
 ```
 
-<!--#endif -->
+# #endif
 
-<!--#if (INCLUDE_API) -->
+# #if (INCLUDE_API)
 
 ### Using the shipped protobufs (optional)
 
@@ -124,7 +124,7 @@ Your project file should look similar to this:
 </Project>
 ```
 
-<!--#endif -->
+# #endif
 
 ## Versioning
 


### PR DESCRIPTION
## Summary
Same root cause, two blast radii — `.template.config/template.json` configures `.md` conditional processing for shell-style `# #if` / `# #endif` (matching the convention used everywhere else, e.g. `docs/index.md`), but several source `.md` files were written with HTML-comment-style `<!--#if (...) -->` instead. The mismatch means the template engine never recognizes the directive, so it passes through literally into every generated project.

Affected files (converted to `# #if` style):
- `docs/events/domain_events.md`, `docs/events/integration_events.md` — leaked markers into the generated docs site's event overview pages
- `ProjectREADME.md` (becomes the generated project's root `README.md`) and `src/AppDomain.Contracts/README.md` — much bigger blast radius, ~100 leaked marker lines making the generated README essentially unreadable

Found while testing default `dotnet new mmt` generation end-to-end (install → generate → build → docs build) for the `feat/nest-event-docs-by-kind` work, then swept the rest of the repo for the same style-mismatch pattern across all three conditional-configured extensions (`.slnx`, `.yml`, `.md`).

## Test plan
- [x] `dotnet new install ./ --force`
- [x] `dotnet new mmt -n VerifyMe --allow-scripts yes --local` (default flags) — restore + build succeed, no leaked markers anywhere in generated output, README renders correctly (Orleans line excluded, sample section included)
- [x] `dotnet new mmt -n VerifyMe2 --allow-scripts yes --local --no-sample --orleans` — opposite conditional branches: Orleans line included, sample section correctly excluded, no leaked markers
- [x] `bun run docs:build` on generated project — vitepress build succeeds, rendered HTML clean
- [x] `dotnet test` on generated `TestService` — 146 passed
- [x] `dotnet test AppDomain.slnx` (unit/arch) — 510 passed
- [x] `dotnet test libs/Momentum/Momentum.slnx` — 636 passed, 3 skipped
- [x] Repo-wide grep confirms no other `.md`/`.yml`/`.slnx` files have the wrong conditional-comment style for their configured evaluator

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qsu6wTTcdeYpjSnkGu3nqS