### PR TITLE
Consolidate Dependabot updates (GrpcCore beta.14, setup-dotnet v6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           distribution: "zulu"
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -242,7 +242,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -281,7 +281,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup .NET 10
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: "10.0.x"
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 

--- a/.github/workflows/publish-libs.yml
+++ b/.github/workflows/publish-libs.yml
@@ -64,7 +64,7 @@ jobs:
           fetch-depth: 0 # Fetching all history for version calculation and release notes (prev vs now)
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 

--- a/.github/workflows/publish-template.yml
+++ b/.github/workflows/publish-template.yml
@@ -55,7 +55,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project are documented in this file, grouped by date
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2026-07-26]
+
+### Changed
+
+- **Dependencies**: consolidated pending Dependabot updates —
+  `OpenTelemetry.Instrumentation.GrpcCore` 1.0.0-beta.13 → 1.0.0-beta.14 and the
+  `actions/setup-dotnet` GitHub Action v5 → v6 across all workflows. (The OpenTelemetry core and
+  instrumentation packages were already at 1.17.0.) `Refitter.MSBuild` is intentionally **not**
+  bumped to 2.1.0 — its generator throws `Method not found: ValueStringBuilder.AsSpan()` against the
+  current runtime and breaks E2E client generation.
+
 ## [2026-07-20]
 
 ### Changed

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -109,7 +109,7 @@
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryCoreVersion)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="$(OpenTelemetryInstrumentationVersion)" />
     <!--#if (INCLUDE_GRPC) -->
-    <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcCore" Version="1.0.0-beta.13" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcCore" Version="1.0.0-beta.14" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.15.0-beta.1" />
     <!--#endif -->
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="$(OpenTelemetryInstrumentationVersion)" />


### PR DESCRIPTION
Combines the pending Dependabot dependency PRs into one, superseding **#297, #300, #302, #305**.

## Included
- **OpenTelemetry.Instrumentation.GrpcCore** `1.0.0-beta.13` → `1.0.0-beta.14` (from #300 / #305)
- **actions/setup-dotnet** `v5` → `v6` across all 5 workflows (#297)

## Intentionally excluded
- **OpenTelemetry group core/instrumentation** (#300) — already at `1.17.0` on `main`, nothing to change.
- **Refitter.MSBuild 2.1.0** (#302) — **breaks the build**: its generator throws `Method not found: System.Text.ValueStringBuilder.AsSpan()` against the current runtime, failing E2E client generation. Held at `2.0.0` (see the pinning comment in `Directory.Packages.props`).

## Verification
- `dotnet build AppDomain.slnx` — succeeds, 0 warnings / 0 errors.

Once merged, the four superseded Dependabot branches/PRs are closed and deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)