### PR TITLE
Add Result validation operators and IEndpointDefinition auto-discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project are documented in this file, grouped by date
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2026-07-27]
+
+### Added
+
+- **Extensions**: `Result<T>` now has an implicit conversion from `ValidationFailure` and an explicit
+  conversion from `ValidationResult`, so a handler can `return failure;` (single failure) or
+  `return (Result<T>)validationResult;` instead of hand-building the failure list.
+- **ServiceDefaults.Api**: `IEndpointDefinition` + `IEndpointRouteBuilder.MapEndpoints(assembly?, predicate?)` —
+  feature endpoint groups implement `static RouteGroupBuilder MapEndpoints(IEndpointRouteBuilder)` and are
+  auto-discovered (in deterministic full-name order) by scanning an assembly, replacing per-feature
+  `app.MapXEndpoints()` wiring. `MapEndpoints` nests every matched group under a shared parent group and
+  returns it, so conventions fan out to all mapped endpoints (`app.MapEndpoints(asm).RequireAuthorization()`).
+  An optional `Func<Type, bool>` predicate filters which definitions a call maps, and the method can be
+  called multiple times with complementary predicates to give different endpoint sets different conventions
+  (e.g. authorized vs anonymous). The sample's `CashierEndpoints`/`InvoiceEndpoints` now implement it, and
+  `Program.cs` calls a single `app.MapEndpoints(typeof(Program).Assembly)`.
+
 ## [2026-07-26]
 
 ### Changed

--- a/libs/Momentum/src/Momentum.Extensions/Result.cs
+++ b/libs/Momentum/src/Momentum.Extensions/Result.cs
@@ -26,4 +26,20 @@ namespace Momentum.Extensions;
 /// </code>
 /// </example>
 [GenerateOneOf]
-public partial class Result<T> : OneOfBase<T, List<ValidationFailure>>;
+public partial class Result<T> : OneOfBase<T, List<ValidationFailure>>
+{
+    /// <summary>
+    ///     Creates a failed <see cref="Result{T}" /> from a single <see cref="ValidationFailure" />,
+    ///     so a handler can <c>return failure;</c> directly.
+    /// </summary>
+    public static implicit operator Result<T>(ValidationFailure failure) =>
+        new Result<T>(new List<ValidationFailure> { failure });
+
+    /// <summary>
+    ///     Creates a failed <see cref="Result{T}" /> from a <see cref="ValidationResult" />'s errors.
+    ///     Explicit because a valid result carries no failures — check <see cref="ValidationResult.IsValid" />
+    ///     before converting.
+    /// </summary>
+    public static explicit operator Result<T>(ValidationResult validationResult) =>
+        new Result<T>(validationResult.Errors);
+}

--- a/libs/Momentum/src/Momentum.ServiceDefaults.Api/EndpointMappingExtensions.cs
+++ b/libs/Momentum/src/Momentum.ServiceDefaults.Api/EndpointMappingExtensions.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Momentum .NET. All rights reserved.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+
+namespace Momentum.ServiceDefaults.Api;
+
+[ExcludeFromCodeCoverage]
+public static class EndpointMappingExtensions
+{
+    private static readonly Type EndpointDefinitionType = typeof(IEndpointDefinition);
+
+    /// <summary>
+    ///     Discovers classes implementing <see cref="IEndpointDefinition" /> in the specified assembly
+    ///     and maps their endpoints under a shared parent group.
+    /// </summary>
+    /// <param name="routeBuilder">The endpoint route builder to register endpoints with.</param>
+    /// <param name="assembly">
+    ///     The assembly to scan for endpoint definitions. Defaults to the entry assembly.
+    /// </param>
+    /// <param name="predicate">
+    ///     Optional filter selecting which endpoint definition types this call maps. When <c>null</c>,
+    ///     all discovered definitions are mapped. Call this method multiple times with complementary
+    ///     predicates to give different endpoint sets different conventions — e.g. one call with
+    ///     <c>.RequireAuthorization()</c> and another without. Predicates should partition the types so
+    ///     none is mapped twice (which would produce duplicate routes).
+    /// </param>
+    /// <returns>
+    ///     The parent <see cref="RouteGroupBuilder" /> the matched feature groups are nested under, so
+    ///     conventions applied to it fan out to every endpoint mapped by this call — e.g.
+    ///     <c>app.MapEndpoints(asm, IsAdminEndpoint).RequireAuthorization()</c>.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">
+    ///     Thrown when no assembly is provided and the entry assembly cannot be determined.
+    /// </exception>
+    public static RouteGroupBuilder MapEndpoints(
+        this IEndpointRouteBuilder routeBuilder, Assembly? assembly = null, Func<Type, bool>? predicate = null)
+    {
+        assembly ??= Assembly.GetEntryAssembly()
+                     ?? throw new InvalidOperationException(
+                         "Unable to identify entry assembly for endpoint discovery. Specify the assembly explicitly.");
+
+        // Parent group with an empty prefix: it adds no path segment, but carries conventions applied
+        // to the returned builder down to every nested feature group.
+        var parentGroup = routeBuilder.MapGroup(string.Empty);
+
+        // Order by full name so endpoint (and generated OpenAPI) registration is deterministic —
+        // Type ordering from GetTypes() is not guaranteed.
+        var endpointDefinitionTypes = assembly.GetTypes()
+            .Where(type => type is { IsClass: true, IsAbstract: false } && type.GetInterfaces().Contains(EndpointDefinitionType))
+            .Where(type => predicate is null || predicate(type))
+            .OrderBy(type => type.FullName, StringComparer.Ordinal)
+            .ToList();
+
+        if (endpointDefinitionTypes.Count == 0)
+        {
+            // A predicate matching nothing is a deliberate caller filter, not a misconfiguration —
+            // only log when the assembly genuinely has no endpoint definitions.
+            if (predicate is null)
+            {
+                var logger = routeBuilder.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger("EndpointMapping");
+                logger?.LogInformation("No IEndpointDefinition implementations found in assembly {AssemblyName}", assembly.GetName().Name);
+            }
+
+            return parentGroup;
+        }
+
+        foreach (var definitionType in endpointDefinitionTypes)
+        {
+            var method = definitionType.GetMethod(
+                nameof(IEndpointDefinition.MapEndpoints), BindingFlags.Public | BindingFlags.Static, [typeof(IEndpointRouteBuilder)]);
+
+            method?.Invoke(null, [parentGroup]);
+        }
+
+        return parentGroup;
+    }
+}

--- a/libs/Momentum/src/Momentum.ServiceDefaults.Api/IEndpointDefinition.cs
+++ b/libs/Momentum/src/Momentum.ServiceDefaults.Api/IEndpointDefinition.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Momentum .NET. All rights reserved.
+
+using Microsoft.AspNetCore.Routing;
+
+namespace Momentum.ServiceDefaults.Api;
+
+/// <summary>
+///     Marks a class as a feature endpoint group that can be auto-discovered and mapped by
+///     <see cref="EndpointMappingExtensions.MapEndpoints" />.
+/// </summary>
+public interface IEndpointDefinition
+{
+    /// <summary>
+    ///     Maps the endpoints for this feature to the specified route builder.
+    /// </summary>
+    /// <param name="routes">The endpoint route builder to register endpoints with.</param>
+    /// <returns>
+    ///     The <see cref="RouteGroupBuilder" /> the endpoints were mapped under, so callers can apply
+    ///     group-wide conventions (authorization, rate limiting, endpoint filters, etc.).
+    /// </returns>
+    static abstract RouteGroupBuilder MapEndpoints(IEndpointRouteBuilder routes);
+}

--- a/libs/Momentum/tests/Momentum.Extensions.Tests/ResultTests.cs
+++ b/libs/Momentum/tests/Momentum.Extensions.Tests/ResultTests.cs
@@ -110,4 +110,35 @@ public class ResultTests
         result.IsT1.ShouldBeTrue();
         result.AsT1.ShouldBeEmpty();
     }
+
+    [Fact]
+    public void ImplicitConversion_FromSingleValidationFailure_ShouldCreateFailureResult()
+    {
+        // Arrange
+        var failure = new ValidationFailure("Name", "Name is required");
+
+        // Act
+        Result<string> result = failure;
+
+        // Assert
+        result.IsT1.ShouldBeTrue();
+        result.AsT1.ShouldHaveSingleItem().ShouldBe(failure);
+    }
+
+    [Fact]
+    public void ExplicitConversion_FromValidationResult_ShouldCreateFailureResult()
+    {
+        // Arrange
+        var validationResult = new ValidationResult([
+            new ValidationFailure("Name", "Name is required"),
+            new ValidationFailure("Email", "Email is invalid")
+        ]);
+
+        // Act
+        var result = (Result<string>)validationResult;
+
+        // Assert
+        result.IsT1.ShouldBeTrue();
+        result.AsT1.ShouldBe(validationResult.Errors);
+    }
 }

--- a/libs/Momentum/tests/Momentum.ServiceDefaults.Api.Tests/EndpointMappingExtensionsTests.cs
+++ b/libs/Momentum/tests/Momentum.ServiceDefaults.Api.Tests/EndpointMappingExtensionsTests.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Momentum .NET. All rights reserved.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Momentum.ServiceDefaults.Api.Tests;
+
+public class EndpointMappingExtensionsTests
+{
+    private static readonly Func<Type, bool> OnlyTestDefinitions =
+        type => type == typeof(AlphaEndpoints) || type == typeof(BravoEndpoints);
+
+    [Fact]
+    public void MapEndpoints_MapsAllMatchedDefinitions()
+    {
+        var app = WebApplication.CreateBuilder().Build();
+
+        app.MapEndpoints(typeof(EndpointMappingExtensionsTests).Assembly, OnlyTestDefinitions);
+
+        var patterns = RoutePatterns(app);
+        patterns.ShouldContain(p => p.Contains("alpha"));
+        patterns.ShouldContain(p => p.Contains("bravo"));
+    }
+
+    [Fact]
+    public void MapEndpoints_WithPredicate_MapsOnlyMatchingDefinitions()
+    {
+        var app = WebApplication.CreateBuilder().Build();
+
+        app.MapEndpoints(typeof(EndpointMappingExtensionsTests).Assembly, type => type == typeof(AlphaEndpoints));
+
+        var patterns = RoutePatterns(app);
+        patterns.ShouldContain(p => p.Contains("alpha"));
+        patterns.ShouldNotContain(p => p.Contains("bravo"));
+    }
+
+    [Fact]
+    public void MapEndpoints_CanBeCalledMultipleTimes_PartitioningDefinitions()
+    {
+        var app = WebApplication.CreateBuilder().Build();
+
+        app.MapEndpoints(typeof(EndpointMappingExtensionsTests).Assembly, type => type == typeof(AlphaEndpoints));
+        app.MapEndpoints(typeof(EndpointMappingExtensionsTests).Assembly, type => type == typeof(BravoEndpoints));
+
+        var patterns = RoutePatterns(app);
+        patterns.ShouldContain(p => p.Contains("alpha"));
+        patterns.ShouldContain(p => p.Contains("bravo"));
+    }
+
+    [Fact]
+    public void MapEndpoints_ConventionOnReturnedGroup_AppliesToAllMappedEndpoints()
+    {
+        var app = WebApplication.CreateBuilder().Build();
+
+        var group = app.MapEndpoints(typeof(EndpointMappingExtensionsTests).Assembly, OnlyTestDefinitions);
+        group.WithMetadata(new TestMarker());
+
+        var endpoints = Endpoints(app);
+        endpoints.Count.ShouldBe(2);
+        endpoints.ShouldAllBe(e => e.Metadata.GetMetadata<TestMarker>() != null);
+    }
+
+    [Fact]
+    public void MapEndpoints_SeparateCalls_ApplyConventionsIndependently()
+    {
+        var app = WebApplication.CreateBuilder().Build();
+
+        app.MapEndpoints(typeof(EndpointMappingExtensionsTests).Assembly, type => type == typeof(AlphaEndpoints))
+            .WithMetadata(new TestMarker());
+        app.MapEndpoints(typeof(EndpointMappingExtensionsTests).Assembly, type => type == typeof(BravoEndpoints));
+
+        var marked = Endpoints(app).Where(e => e.Metadata.GetMetadata<TestMarker>() != null).ToList();
+        marked.ShouldHaveSingleItem();
+        ((RouteEndpoint)marked[0]).RoutePattern.RawText.ShouldNotBeNull().ShouldContain("alpha");
+    }
+
+    [Fact]
+    public void MapEndpoints_WhenPredicateMatchesNothing_ReturnsGroupAndMapsNoEndpoints()
+    {
+        var app = WebApplication.CreateBuilder().Build();
+
+        var group = app.MapEndpoints(typeof(EndpointMappingExtensionsTests).Assembly, _ => false);
+
+        group.ShouldNotBeNull();
+        Endpoints(app).ShouldBeEmpty();
+    }
+
+    private static List<Endpoint> Endpoints(WebApplication app) =>
+        ((IEndpointRouteBuilder)app).DataSources.SelectMany(dataSource => dataSource.Endpoints).ToList();
+
+    private static List<string> RoutePatterns(WebApplication app) =>
+        Endpoints(app).OfType<RouteEndpoint>().Select(endpoint => endpoint.RoutePattern.RawText ?? string.Empty).ToList();
+
+    private sealed class TestMarker;
+
+    private sealed class AlphaEndpoints : IEndpointDefinition
+    {
+        public static RouteGroupBuilder MapEndpoints(IEndpointRouteBuilder routes)
+        {
+            var group = routes.MapGroup("alpha");
+            group.MapGet("/", () => Results.Ok("alpha"));
+
+            return group;
+        }
+    }
+
+    private sealed class BravoEndpoints : IEndpointDefinition
+    {
+        public static RouteGroupBuilder MapEndpoints(IEndpointRouteBuilder routes)
+        {
+            var group = routes.MapGroup("bravo");
+            group.MapGet("/", () => Results.Ok("bravo"));
+
+            return group;
+        }
+    }
+}

--- a/src/AppDomain.Api/Cashiers/CashierEndpoints.cs
+++ b/src/AppDomain.Api/Cashiers/CashierEndpoints.cs
@@ -4,18 +4,19 @@ using AppDomain.Api.Cashiers.Models;
 using AppDomain.Cashiers.Commands;
 using AppDomain.Cashiers.Contracts.Models;
 using AppDomain.Cashiers.Queries;
+using Momentum.ServiceDefaults.Api;
 
 namespace AppDomain.Api.Cashiers;
 
 /// <summary>
 ///     Defines minimal API endpoints for cashier operations.
 /// </summary>
-public static class CashierEndpoints
+public class CashierEndpoints : IEndpointDefinition
 {
     /// <summary>
     ///     Maps all cashier REST endpoints under the /cashiers route group.
     /// </summary>
-    public static RouteGroupBuilder MapCashierEndpoints(this IEndpointRouteBuilder routes)
+    public static RouteGroupBuilder MapEndpoints(IEndpointRouteBuilder routes)
     {
         var group = routes.MapGroup("cashiers")
             .WithTags("Cashiers");

--- a/src/AppDomain.Api/Invoices/InvoiceEndpoints.cs
+++ b/src/AppDomain.Api/Invoices/InvoiceEndpoints.cs
@@ -5,18 +5,19 @@ using AppDomain.Api.Invoices.Models;
 using AppDomain.Invoices.Commands;
 using AppDomain.Invoices.Contracts.Models;
 using AppDomain.Invoices.Queries;
+using Momentum.ServiceDefaults.Api;
 
 namespace AppDomain.Api.Invoices;
 
 /// <summary>
 ///     Defines minimal API endpoints for invoice operations.
 /// </summary>
-public static class InvoiceEndpoints
+public class InvoiceEndpoints : IEndpointDefinition
 {
     /// <summary>
     ///     Maps all invoice REST endpoints under the /invoices route group.
     /// </summary>
-    public static RouteGroupBuilder MapInvoiceEndpoints(this IEndpointRouteBuilder routes)
+    public static RouteGroupBuilder MapEndpoints(IEndpointRouteBuilder routes)
     {
         var group = routes.MapGroup("invoices")
             .WithTags("Invoices");

--- a/src/AppDomain.Api/Program.cs
+++ b/src/AppDomain.Api/Program.cs
@@ -3,10 +3,6 @@
 //#if (INCLUDE_ORLEANS)
 using AppDomain.Api.Infrastructure.Extensions;
 //#endif
-//#if (INCLUDE_SAMPLE)
-using AppDomain.Api.Cashiers;
-using AppDomain.Api.Invoices;
-//#endif
 using AppDomain.Infrastructure;
 //#if (USE_KAFKA)
 using Momentum.Extensions.Messaging.Kafka;
@@ -52,8 +48,9 @@ app.ConfigureApiUsingDefaults();
 app.UseFrontendIntegration();
 //#endif
 //#if (INCLUDE_SAMPLE)
-app.MapCashierEndpoints();
-app.MapInvoiceEndpoints();
+// Pass the assembly explicitly: Assembly.GetEntryAssembly() is null during build-time OpenAPI
+// document generation, which would otherwise discover no endpoints and emit an empty spec.
+app.MapEndpoints(typeof(Program).Assembly);
 //#endif
 app.MapDefaultHealthCheckEndpoints();
 

--- a/tests/AppDomain.Tests/Unit/Cashier/CashierEndpointsTests.cs
+++ b/tests/AppDomain.Tests/Unit/Cashier/CashierEndpointsTests.cs
@@ -14,7 +14,7 @@ public class CashierEndpointsTests : EndpointTest
 {
     public CashierEndpointsTests()
     {
-        ConfigureApp(app => app.MapCashierEndpoints());
+        ConfigureApp(app => CashierEndpoints.MapEndpoints(app));
     }
 
     [Fact]

--- a/tests/AppDomain.Tests/Unit/Invoices/InvoiceEndpointsTests.cs
+++ b/tests/AppDomain.Tests/Unit/Invoices/InvoiceEndpointsTests.cs
@@ -17,7 +17,7 @@ public class InvoiceEndpointsTests : EndpointTest
 {
     public InvoiceEndpointsTests()
     {
-        ConfigureApp(app => app.MapInvoiceEndpoints());
+        ConfigureApp(app => InvoiceEndpoints.MapEndpoints(app));
     }
 
     // -- Helpers --


### PR DESCRIPTION
Two independent improvements salvaged from the abandoned `feature/0.0.10` branch (rebuilt fresh on `main` — the rest of that branch was a superseded messaging refactor, now dropped).

## Changes
- **`Result<T>` operators** (`Momentum.Extensions`): implicit conversion from `ValidationFailure`, explicit from `ValidationResult`. Handlers can `return failure;` or `return (Result<T>)validationResult;` instead of hand-building the failure list.
- **`IEndpointDefinition` auto-discovery** (`Momentum.ServiceDefaults.Api`): feature endpoint groups implement `static void MapEndpoints(IEndpointRouteBuilder)`; `app.MapEndpoints(assembly?)` reflection-scans and maps them in **deterministic full-name order**. `CashierEndpoints`/`InvoiceEndpoints` now implement it; `Program.cs` calls one `app.MapEndpoints(typeof(Program).Assembly)`; the endpoint unit tests call the static method directly.

## Notes
- `Program.cs` passes the assembly **explicitly** on purpose: `Assembly.GetEntryAssembly()` is `null` during build-time OpenAPI generation, which would otherwise discover no endpoints and emit an empty `openapi.json`. Deterministic ordering keeps the generated spec byte-identical (verified: no `openapi.json` diff vs `main`).

## Verification
- `dotnet build AppDomain.slnx` — 0 warnings / 0 errors.
- Endpoint + unit tests pass (149 unit incl. the converted endpoint tests).
- `openapi.json` unchanged vs `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)