### PR TITLE
Consolidate Dependabot updates (Wolverine 6.23, Orleans 10.2.2, Grpc.Tools, Scalar)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project are documented in this file, grouped by date
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2026-07-28]
+
+### Changed
+
+- **Dependencies**: consolidated pending Dependabot updates — `WolverineFx` (+`.Kafka`, `.Postgresql`,
+  `.RuntimeCompilation`) `6.21.0` → `6.23.0` (Kafka aligned manually — Dependabot's group missed it),
+  `Microsoft.Orleans` `10.2.1` → `10.2.2`, `Grpc.Tools` `2.82.0` → `2.83.0`, and `Scalar.AspNetCore`
+  `2.16.15` → `2.16.16`. Two updates are intentionally held back: `Refitter.MSBuild` 2.1.0 (its generator
+  breaks E2E client generation — `Method not found: ValueStringBuilder.AsSpan()`) and
+  `SonarAnalyzer.CSharp` 10.30 (introduces new analyzer rules that fail the build on existing code,
+  including a false-positive S8969 that conflicts with the compiler's nullability analysis).
+
 ## [2026-07-27]
 
 ### Added

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <AspireAppHostSdkVersion>$(AspireVersion)</AspireAppHostSdkVersion>
     <MicrosoftExtensionsVersion>10.0.10</MicrosoftExtensionsVersion>
     <!--#if (INCLUDE_ORLEANS) -->
-    <MicrosoftOrleansVersion>10.2.1</MicrosoftOrleansVersion>
+    <MicrosoftOrleansVersion>10.2.2</MicrosoftOrleansVersion>
     <!--#endif -->
     <OpenTelemetryCoreVersion>1.17.0</OpenTelemetryCoreVersion>
     <OpenTelemetryInstrumentationVersion>1.17.0</OpenTelemetryInstrumentationVersion>
@@ -48,7 +48,7 @@
     <PackageVersion Include="Grpc.AspNetCore.Server.Reflection" Version="$(GrpcVersion)" />
     <PackageVersion Include="Grpc.AspNetCore.Web" Version="$(GrpcVersion)" />
     <PackageVersion Include="Grpc.Net.Client" Version="$(GrpcVersion)" />
-    <PackageVersion Include="Grpc.Tools" Version="2.82.0" />
+    <PackageVersion Include="Grpc.Tools" Version="2.83.0" />
     <!--#endif -->
     <PackageVersion Include="linq2db" Version="6.3.0" />
     <PackageVersion Include="linq2db.Extensions" Version="6.3.0" />
@@ -115,7 +115,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="$(OpenTelemetryInstrumentationVersion)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="$(OpenTelemetryInstrumentationVersion)" />
     <PackageVersion Include="Riok.Mapperly" Version="4.3.1" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.16.15" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.16.16" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Serilog.Exceptions" Version="8.4.0" />
     <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
@@ -126,12 +126,12 @@
     <PackageVersion Include="Testcontainers" Version="4.13.0" />
     <PackageVersion Include="Testcontainers.Kafka" Version="4.13.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.13.0" />
-    <PackageVersion Include="WolverineFx" Version="6.21.0" />
+    <PackageVersion Include="WolverineFx" Version="6.23.0" />
     <!--#if (USE_KAFKA) -->
-    <PackageVersion Include="WolverineFx.Kafka" Version="6.21.0" />
+    <PackageVersion Include="WolverineFx.Kafka" Version="6.23.0" />
     <!--#endif -->
-    <PackageVersion Include="WolverineFx.Postgresql" Version="6.21.0" />
-    <PackageVersion Include="WolverineFx.RuntimeCompilation" Version="6.21.0" />
+    <PackageVersion Include="WolverineFx.Postgresql" Version="6.23.0" />
+    <PackageVersion Include="WolverineFx.RuntimeCompilation" Version="6.23.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>


### PR DESCRIPTION
Combines the pending Dependabot dependency PRs into one, superseding **#308, #309, #310, #311, #314** (and closing the held-back **#312, #313**).

## Included
- **WolverineFx** + `.Kafka` + `.Postgresql` + `.RuntimeCompilation` `6.21.0` → `6.23.0` (#309, #314). `.Kafka` aligned manually — Dependabot's `wolverine` group only bumped 3 of the 4, which would have left Kafka a minor behind its siblings.
- **Microsoft.Orleans** `10.2.1` → `10.2.2` (#308)
- **Grpc.Tools** `2.82.0` → `2.83.0` (#310)
- **Scalar.AspNetCore** `2.16.15` → `2.16.16` (#311)

## Intentionally excluded
- **Refitter.MSBuild 2.1.0** (#312) — generator breaks E2E client generation (`Method not found: System.Text.ValueStringBuilder.AsSpan()`).
- **SonarAnalyzer.CSharp 10.30** (#313) — new analyzer rules fail the build on existing code, including a false-positive **S8969** that conflicts with the compiler's own nullability analysis (removing the flagged `!` triggers CS8620).

## Verification
- `dotnet build AppDomain.slnx` — 0 warnings / 0 errors.
- `dotnet test AppDomain.Tests` — 209/209.
- **Generated-template E2E**: `dotnet new mmt --local` (full config, Wolverine 6.23), booted against real Postgres + Kafka, ran the generated E2E suite → **14/14 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)