### PR TITLE
Bump SonarAnalyzer to 10.30 (fix new findings) + ignore Refitter 2.1.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -73,6 +73,11 @@ updates:
       # ships a matching Roslyn version.
       - dependency-name: "Microsoft.CodeAnalysis.*"
         update-types: ["version-update:semver-major"]
+      # Refitter.MSBuild 2.1.0's generator throws "Method not found:
+      # System.Text.ValueStringBuilder.AsSpan()" against the current runtime and breaks E2E client
+      # generation. Skip 2.1.0 only — a later patch should pick back up.
+      - dependency-name: "Refitter.MSBuild"
+        versions: ["2.1.0"]
 
   # NPM packages for VitePress documentation (main docs)
   - package-ecosystem: "npm"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Analyzers**: `SonarAnalyzer.CSharp` `10.29.0.143774` → `10.30.0.144632`. The new version adds rules
+  that flagged pre-existing code (warnings-as-errors), all addressed: **S8949** — pass the request /
+  test `CancellationToken` to `WriteAsync`/`WriteAsJsonAsync`/`StartAsync`/`DeserializeAsync`/
+  `LoadDocumentationAsync`; **S8969** — removed redundant null-forgiving operators across app and test
+  code. One S8969 site in `CloudEventMapper` is suppressed with a comment instead: dropping the `!`
+  there re-exposes a benign `CS8620` variance (CloudNative's `IsCloudEvent` annotates the Kafka key
+  `string?` while Wolverine's `IIncomingMapper` fixes it `string` — identical at runtime).
+- **CI/Dependabot**: ignore `Refitter.MSBuild` `2.1.0` specifically (its generator breaks E2E client
+  generation); a later patch will be proposed again automatically.
 - **Dependencies**: consolidated pending Dependabot updates — `WolverineFx` (+`.Kafka`, `.Postgresql`,
   `.RuntimeCompilation`) `6.21.0` → `6.23.0` (Kafka aligned manually — Dependabot's group missed it),
   `Microsoft.Orleans` `10.2.1` → `10.2.2`, `Grpc.Tools` `2.82.0` → `2.83.0`, and `Scalar.AspNetCore`

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -120,7 +120,7 @@
     <PackageVersion Include="Serilog.Exceptions" Version="8.4.0" />
     <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
-    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.29.0.143774" />
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.30.0.144632" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.55.0" />
     <PackageVersion Include="System.Net.Http.Json" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Testcontainers" Version="4.13.0" />

--- a/libs/Momentum/src/Momentum.Extensions.EventMarkdownGenerator/Services/XmlDocumentationParser.cs
+++ b/libs/Momentum/src/Momentum.Extensions.EventMarkdownGenerator/Services/XmlDocumentationParser.cs
@@ -31,7 +31,7 @@ public class XmlDocumentationParser(ILogger<XmlDocumentationService>? logger = n
         if (xmlFilePaths == null)
             return false;
 
-        var loadTasks = xmlFilePaths.Select(path => _xmlService.LoadDocumentationAsync(path));
+        var loadTasks = xmlFilePaths.Select(path => _xmlService.LoadDocumentationAsync(path, cancellationToken));
         var loadResults = await Task.WhenAll(loadTasks).WaitAsync(cancellationToken);
 
         return loadResults.Any(result => result);

--- a/libs/Momentum/src/Momentum.Extensions.Messaging.Kafka/GlobalSuppressions.cs
+++ b/libs/Momentum/src/Momentum.Extensions.Messaging.Kafka/GlobalSuppressions.cs
@@ -7,3 +7,8 @@ using System.Diagnostics.CodeAnalysis;
 
 [assembly: SuppressMessage("Performance", "CA1873",
     Justification = "Logging argument evaluation cost acceptable for startup-time configuration logging")]
+
+[assembly: SuppressMessage("Major Code Smell", "S8969",
+    Justification = "CloudEventMapper uses a null-forgiving operator on the Kafka message to bridge a " +
+                    "benign key-annotation variance (string vs string?) between Wolverine's IIncomingMapper " +
+                    "and CloudNative's IsCloudEvent; without it the compiler reports CS8620.")]

--- a/libs/Momentum/src/Momentum.ServiceDefaults/HealthChecks/HealthCheckSetupExtensions.cs
+++ b/libs/Momentum/src/Momentum.ServiceDefaults/HealthChecks/HealthCheckSetupExtensions.cs
@@ -87,7 +87,7 @@ public static partial class HealthCheckSetupExtensions
 
         return outputResult
             ? WriteReportObject(httpContext, report)
-            : httpContext.Response.WriteAsync(report.Status.ToString());
+            : httpContext.Response.WriteAsync(report.Status.ToString(), httpContext.RequestAborted);
     }
 
     private static void LogHealthCheckResponse(ILogger logger, HealthReport report)
@@ -127,7 +127,7 @@ public static partial class HealthCheckSetupExtensions
                 .ToList()
         };
 
-        return context.Response.WriteAsJsonAsync(response, options: JsonSerializerOptions);
+        return context.Response.WriteAsJsonAsync(response, options: JsonSerializerOptions, cancellationToken: context.RequestAborted);
     }
 
     private static ILogger GetHealthCheckLogger(IServiceProvider provider)

--- a/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTests.cs
+++ b/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/IntegrationTests.cs
@@ -199,12 +199,12 @@ public class IntegrationTests
         // Validate AppDomain section exists (contains CashierCreated)
         var appDomainSection = sidebarItems.FirstOrDefault(s => s.Text == "AppDomain");
         appDomainSection.ShouldNotBeNull();
-        appDomainSection!.Items.Count.ShouldBe(7);
+        appDomainSection.Items.Count.ShouldBe(7);
 
         // Find the Cashiers subsection within AppDomain section
         var cashiersSubsection = appDomainSection.Items.FirstOrDefault(i => i.Text == "Cashiers");
         cashiersSubsection.ShouldNotBeNull();
-        cashiersSubsection!.Items.ShouldNotBeNull();
+        cashiersSubsection.Items.ShouldNotBeNull();
         cashiersSubsection.Items.Count.ShouldBe(1);
 
         // Check that CashierCreated is in the Cashiers subsection
@@ -215,7 +215,7 @@ public class IntegrationTests
         // Validate schemas section exists
         var schemasSection = sidebarItems.FirstOrDefault(s => s.Text == "Schemas");
         schemasSection.ShouldNotBeNull();
-        schemasSection!.Items.Count.ShouldBeGreaterThan(0);
+        schemasSection.Items.Count.ShouldBeGreaterThan(0);
     }
 
     [Fact]
@@ -244,11 +244,11 @@ public class IntegrationTests
             // Mirrors GenerateCommand.CollectAllSchemaTypes: schema types come from the event's own
             // complex-type properties, not from EntityType directly.
             var schemaTypes = TypeUtils.CollectComplexTypesFromProperties(cashierCreatedEvent.Metadata.Properties);
-            schemaTypes.ShouldContain(entityType!);
+            schemaTypes.ShouldContain(entityType);
 
             var generatedMarkdown = markdownGenerator.GenerateMarkdown(cashierCreatedEvent, outputDir, schemaTypes: schemaTypes);
 
-            generatedMarkdown.Content.ShouldContain($"**Entity:** [Cashier](/events/schemas/{entityType!.FullName}.md)");
+            generatedMarkdown.Content.ShouldContain($"**Entity:** [Cashier](/events/schemas/{entityType.FullName}.md)");
         }
         finally
         {

--- a/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/StringEncodingAttributeTests.cs
+++ b/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/StringEncodingAttributeTests.cs
@@ -27,7 +27,7 @@ public class StringEncodingAttributeTests
         var usage = typeof(StringEncodingAttribute)
             .GetCustomAttribute<AttributeUsageAttribute>();
         usage.ShouldNotBeNull();
-        (usage!.ValidOn & AttributeTargets.Assembly).ShouldNotBe((AttributeTargets)0);
+        (usage.ValidOn & AttributeTargets.Assembly).ShouldNotBe((AttributeTargets)0);
     }
 
     [Fact]
@@ -36,7 +36,7 @@ public class StringEncodingAttributeTests
         var usage = typeof(StringEncodingAttribute)
             .GetCustomAttribute<AttributeUsageAttribute>();
         usage.ShouldNotBeNull();
-        (usage!.ValidOn & AttributeTargets.Class).ShouldNotBe((AttributeTargets)0);
+        (usage.ValidOn & AttributeTargets.Class).ShouldNotBe((AttributeTargets)0);
     }
 
     [Fact]
@@ -45,6 +45,6 @@ public class StringEncodingAttributeTests
         var usage = typeof(StringEncodingAttribute)
             .GetCustomAttribute<AttributeUsageAttribute>();
         usage.ShouldNotBeNull();
-        (usage!.ValidOn & AttributeTargets.Property).ShouldNotBe((AttributeTargets)0);
+        (usage.ValidOn & AttributeTargets.Property).ShouldNotBe((AttributeTargets)0);
     }
 }

--- a/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/XmlDocumentationParserTests.cs
+++ b/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/XmlDocumentationParserTests.cs
@@ -29,7 +29,7 @@ public class XmlDocumentationParserTests
         cashierCreatedType.ShouldNotBeNull();
 
         // Get documentation for the event
-        var documentation = parser.GetEventDocumentation(cashierCreatedType!);
+        var documentation = parser.GetEventDocumentation(cashierCreatedType);
 
         // Verify summary is parsed
         documentation.Summary.ShouldContain("Published when a new cashier is successfully created");

--- a/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/XmlParsingDebugTests.cs
+++ b/libs/Momentum/tests/Momentum.Extensions.EventMarkdownGenerator.Tests/XmlParsingDebugTests.cs
@@ -25,7 +25,7 @@ public class XmlParsingDebugTests
         var cashierCreatedType = assembly.GetType("AppDomain.Cashiers.Contracts.IntegrationEvents.CashierCreated");
         cashierCreatedType.ShouldNotBeNull();
 
-        var documentation = parser.GetEventDocumentation(cashierCreatedType!);
+        var documentation = parser.GetEventDocumentation(cashierCreatedType);
 
         // Debug output - let's see what we actually get
         Console.WriteLine($"Summary: {documentation.Summary}");

--- a/libs/Momentum/tests/Momentum.ServiceDefaults.Api.Tests/HealthCheckSetupExtensionsTests.cs
+++ b/libs/Momentum/tests/Momentum.ServiceDefaults.Api.Tests/HealthCheckSetupExtensionsTests.cs
@@ -1,0 +1,106 @@
+// Copyright (c) Momentum .NET. All rights reserved.
+
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+using Momentum.ServiceDefaults.HealthChecks;
+
+namespace Momentum.ServiceDefaults.Api.Tests;
+
+public class HealthCheckSetupExtensionsTests
+{
+    private static async Task<IHost> StartAppAsync(string environment, HealthStatus status)
+    {
+        WebApplicationBuilder builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = environment });
+        builder.WebHost.UseTestServer();
+
+        builder.Services.AddSingleton<HealthCheckStatusStore>();
+        builder.Services.AddAuthentication();
+        builder.Services.AddAuthorization();
+        builder.Services.AddHealthChecks().AddCheck("test", () => new HealthCheckResult(status));
+
+        var app = builder.Build();
+
+        // Make requests look like loopback so RequireHost("localhost") + the LocalhostEndpointFilter pass.
+        app.Use(async (context, next) =>
+        {
+            context.Connection.RemoteIpAddress = IPAddress.Loopback;
+            await next(context);
+        });
+
+        app.MapDefaultHealthCheckEndpoints();
+
+        await app.StartAsync(TestContext.Current.CancellationToken);
+
+        return app;
+    }
+
+    [Fact]
+    public async Task Status_OnFreshApp_ReturnsCachedHealthyLiveness()
+    {
+        using var app = await StartAppAsync("Production", HealthStatus.Healthy);
+        var client = app.GetTestClient();
+
+        var response = await client.GetAsync("/status", TestContext.Current.CancellationToken);
+
+        // No health check has run yet, so the store returns its default (Healthy).
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken)).ShouldBe("Healthy");
+    }
+
+    [Fact]
+    public async Task HealthInternal_InDevelopment_WritesDetailedJsonReport()
+    {
+        using var app = await StartAppAsync("Development", HealthStatus.Healthy);
+        var client = app.GetTestClient();
+
+        var response = await client.GetAsync("/health/internal", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        body.TrimStart().ShouldStartWith("{");
+        body.ShouldContain("Healthy");
+    }
+
+    [Fact]
+    public async Task HealthInternal_InProduction_WritesStatusTextOnly()
+    {
+        using var app = await StartAppAsync("Production", HealthStatus.Healthy);
+        var client = app.GetTestClient();
+
+        var response = await client.GetAsync("/health/internal", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken)).ShouldBe("Healthy");
+    }
+
+    [Fact]
+    public async Task HealthInternal_WhenUnhealthy_Returns503()
+    {
+        using var app = await StartAppAsync("Production", HealthStatus.Unhealthy);
+        var client = app.GetTestClient();
+
+        var response = await client.GetAsync("/health/internal", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.ServiceUnavailable);
+    }
+
+    [Fact]
+    public async Task Status_AfterUnhealthyCheckRuns_ReflectsCachedUnhealthy()
+    {
+        using var app = await StartAppAsync("Production", HealthStatus.Unhealthy);
+        var client = app.GetTestClient();
+
+        // Running a failing health check caches Unhealthy in the store...
+        await client.GetAsync("/health/internal", TestContext.Current.CancellationToken);
+
+        // ...which /status then reports as a 503.
+        var response = await client.GetAsync("/status", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.ServiceUnavailable);
+        (await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken)).ShouldBe("Unhealthy");
+    }
+}

--- a/libs/Momentum/tests/Momentum.ServiceDefaults.Api.Tests/ProblemDetailsExceptionHandlerTests.cs
+++ b/libs/Momentum/tests/Momentum.ServiceDefaults.Api.Tests/ProblemDetailsExceptionHandlerTests.cs
@@ -148,7 +148,7 @@ public class ProblemDetailsExceptionHandlerTests
     {
         httpContext.Response.Body.Position = 0;
         var body = await JsonSerializer.DeserializeAsync<ProblemDetails>(
-            httpContext.Response.Body, JsonOptions);
+            httpContext.Response.Body, JsonOptions, httpContext.RequestAborted);
         body.ShouldNotBeNull();
         return body;
     }

--- a/src/AppDomain.Api/Infrastructure/Extensions/OrleansExtensions.cs
+++ b/src/AppDomain.Api/Infrastructure/Extensions/OrleansExtensions.cs
@@ -118,7 +118,7 @@ public static class OrleansExtensions
         var serviceKey = registration;
 
         if (registration.ImplementationInstance is not null)
-            return new ServiceDescriptor(typeof(IClusterClient), serviceKey, registration.ImplementationInstance!);
+            return new ServiceDescriptor(typeof(IClusterClient), serviceKey, registration.ImplementationInstance);
 
         if (registration.ImplementationFactory is not null)
         {

--- a/tests/AppDomain.Tests/Architecture/DomainDiscovery.cs
+++ b/tests/AppDomain.Tests/Architecture/DomainDiscovery.cs
@@ -71,7 +71,7 @@ public static class DomainDiscovery
         return GetAppDomainTypes()
             .GetTypes()
             .Where(t => t.Namespace?.Contains(".Actors") == true &&
-                        !t.Namespace!.StartsWith("AppDomain.BackOffice.Orleans") &&
+                        !t.Namespace.StartsWith("AppDomain.BackOffice.Orleans") &&
                         t.GetInterfaces().Any(i => typeof(IGrain).IsAssignableFrom(i)))
             .Select(t => t.Namespace!)
             .ToHashSet();

--- a/tests/AppDomain.Tests/Unit/Common/EndpointTest.cs
+++ b/tests/AppDomain.Tests/Unit/Common/EndpointTest.cs
@@ -42,7 +42,7 @@ public abstract class EndpointTest : IAsyncLifetime
         var builder = CreateAppBuilder();
         App = builder.Build();
         _configureApp?.Invoke(App);
-        await App.StartAsync();
+        await App.StartAsync(TestContext.Current.CancellationToken);
         Client = App.GetTestClient();
     }
 

--- a/tests/AppDomain.Tests/Unit/Infrastructure/OrleansExtensionsTests.cs
+++ b/tests/AppDomain.Tests/Unit/Infrastructure/OrleansExtensionsTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) OrgName. All rights reserved.
 
 using AppDomain.Api.Infrastructure.Extensions;
+using System.Reflection;
 
 namespace AppDomain.Tests.Unit.Infrastructure;
 
@@ -227,5 +228,25 @@ public class OrleansExtensionsTests
         var primaryClientRegistration = builder.Services.Last(s =>
             s.ServiceType == typeof(IClusterClient) && !s.IsKeyedService);
         primaryClientRegistration.Lifetime.ShouldBe(ServiceLifetime.Singleton);
+    }
+
+    [Fact]
+    public void CreateKeyedClusterClient_WhenRegisteredAsInstance_CarriesTheSameInstance()
+    {
+        // Arrange — an IClusterClient registered as a singleton instance (ImplementationInstance set)
+        var instance = Substitute.For<IClusterClient>();
+        var registration = ServiceDescriptor.Singleton(typeof(IClusterClient), instance);
+
+        var method = typeof(OrleansExtensions)
+            .GetMethod("CreateKeyedClusterClient", BindingFlags.NonPublic | BindingFlags.Static);
+        method.ShouldNotBeNull();
+
+        // Act
+        var keyed = (ServiceDescriptor)method.Invoke(null, [registration])!;
+
+        // Assert — a keyed IClusterClient carrying the same instance
+        keyed.IsKeyedService.ShouldBeTrue();
+        keyed.ServiceType.ShouldBe(typeof(IClusterClient));
+        keyed.KeyedImplementationInstance.ShouldBe(instance);
     }
 }


### PR DESCRIPTION
Follow-up to #315, which held back two Dependabot updates. This lands one of them properly and permanently deters the other.

## SonarAnalyzer.CSharp 10.29 → 10.30
The new version adds rules that flagged existing code (warnings-as-errors). All fixed:
- **S8949** (pass a `CancellationToken`) — `WriteAsync`, `WriteAsJsonAsync`, `StartAsync`, `DeserializeAsync`, `LoadDocumentationAsync` now receive the request/test token.
- **S8969** (redundant null-forgiving `!`) — removed across app + test code.
- One S8969 in `CloudEventMapper` is **suppressed with a comment** instead: removing the `!` re-exposes a benign `CS8620` — CloudNative's `IsCloudEvent` annotates the Kafka key `string?` while Wolverine's `IIncomingMapper` fixes it `string` (identical at runtime, interface-locked so the signature can't be changed).

## Dependabot: ignore Refitter.MSBuild 2.1.0
Scoped to the **exact** version (`versions: ["2.1.0"]`) — its generator breaks E2E client generation (`Method not found: ValueStringBuilder.AsSpan()`). A later patch (2.1.1+) will be proposed again automatically, rather than suppressing the dependency forever.

## Verification
- `dotnet build AppDomain.slnx` + `libs/Momentum/Momentum.slnx` — 0 warnings / 0 errors under 10.30.
- Tests: AppDomain 209/209, ServiceDefaults.Api 44/44, EventMarkdownGenerator 163/163 (+3 skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)